### PR TITLE
Add class to entity type map

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -24,8 +24,8 @@ const BREAK = '<br/>';
 
 // Map entity data to element attributes.
 const ENTITY_ATTR_MAP = {
-  [ENTITY_TYPE.LINK]: {url: 'href', rel: 'rel', target: 'target', title: 'title'},
-  [ENTITY_TYPE.IMAGE]: {src: 'src', height: 'height', width: 'width', alt: 'alt'},
+  [ENTITY_TYPE.LINK]: {url: 'href', rel: 'rel', target: 'target', title: 'title', className: 'class'},
+  [ENTITY_TYPE.IMAGE]: {src: 'src', height: 'height', width: 'width', alt: 'alt', className: 'class'},
 };
 
 // Map entity data to element attributes.


### PR DESCRIPTION
If you create a entity like: `Entity.create('LINK', 'MUTABLE', {url: this.state.value, className: 'link'});`
The className will be exported as `class` attribute. 
