### PR TITLE
Add support for atomic decorator

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -284,6 +284,13 @@ class MarkupGenerator {
         let strAttrs = stringifyAttrs(attrs);
         return `<img${strAttrs}/>`;
       } else {
+        if (this.options.inlineDecorator) {
+          const ret = this.options.inlineDecorator(entity, content);
+          if (ret !== null) {
+            return ret;
+          }
+        }
+
         return content;
       }
     }).join('');

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -108,9 +108,11 @@ class MarkupGenerator {
   output: Array<string>;
   totalBlocks: number;
   wrapperTag: ?string;
+  options: ?Object;
 
-  constructor(contentState: ContentState) {
+  constructor(contentState: ContentState, options: Object) {
     this.contentState = contentState;
+    this.options = options;
   }
 
   generate(): string {
@@ -140,8 +142,25 @@ class MarkupGenerator {
       }
     }
     this.indent();
-    this.writeStartTag(blockType);
-    this.output.push(this.renderBlockContent(block));
+
+    let decoratorOutput = null;
+
+    if (blockType === 'atomic' && this.options && this.options.atomicDecorator) {
+      // extract custom data for user
+      const blockData = block.getEntityAt(0) ? Entity.get(block.getEntityAt(0)).getData() : null;
+      // decorator can return null, which will cause processing to occur as normal
+      const decoratorOutput = this.options.atomicDecorator(block, blockData);
+      if (decoratorOutput !== null) {
+        this.output.push(decoratorOutput);
+        this.output.push(`\n`);
+      }
+    }
+
+    // Avoid writing start and end tags for decorator output
+    if (decoratorOutput === null) {
+      this.writeStartTag(blockType);
+      this.output.push(this.renderBlockContent(block));
+    }
     // Look ahead and see if we will nest list.
     let nextBlock = this.getNextBlock();
     if (
@@ -163,7 +182,9 @@ class MarkupGenerator {
     } else {
       this.currentBlock += 1;
     }
-    this.writeEndTag(blockType);
+    if (decoratorOutput === null) {
+      this.writeEndTag(blockType);
+    }
   }
 
   processBlocksAtDepth(depth: number) {
@@ -328,6 +349,6 @@ function encodeAttr(text: string): string {
     .split('"').join('&quot;');
 }
 
-export default function stateToHTML(content: ContentState): string {
-  return new MarkupGenerator(content).generate();
+export default function stateToHTML(content: ContentState, options: Object): string {
+  return new MarkupGenerator(content, options).generate();
 }

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -113,6 +113,9 @@ class MarkupGenerator {
   constructor(contentState: ContentState, options: Object) {
     this.contentState = contentState;
     this.options = options;
+    if (!this.options) {
+      this.options = {};
+    }
   }
 
   generate(): string {


### PR DESCRIPTION
I needed to hack in support for custom styling of atomic blocks, so I came up with (what I hope) is a simple solution.

You pass a decorator function into the stateToHTML method which receives two arguments, the block and the extracted data. The decorator returns a string which is pushed into the output.

Example

``` javascript
stateToHTML(state.getCurrentContent(), {
  'atomicDecorator': (block, data) => {
    // could get data from the block
    // {customType} = Entity.get(block.getEntityAt(0)).getData();
    const {customType} = data;
    if (customType == 'pull-quote') {
      const {content, credit} = data;
      return '<div>' + content + '</div>';
    }
    return null;
  }
})
```

Figured passing a hash would be preferable to passing a closure, just in case more options are warranted in the future.

Not entirely sure this is the best way to handle a decorator when the only thing exposed is a single function call, but it seems to be working properly with the latest Draft.js release.
