### PR TITLE
Add custom style support.

### DIFF
--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -22,6 +22,11 @@ let testCases = testCasesRaw.slice(1).trim().split(SEP).map((text) => {
   return {description, state, html};
 });
 
+const customStyles = {
+  BLUE_ON_RED: (content) => `<span style="color: blue; background-color: red">${content}</span>`,
+  UPPERCASE: (content) => `<span style="text-transform: uppercase">${content}</span>`,
+};
+
 describe('stateToHTML', () => {
   testCases.forEach((testCase) => {
     let {description, state, html} = testCase;
@@ -29,7 +34,7 @@ describe('stateToHTML', () => {
       let contentState = ContentState.createFromBlockArray(
         convertFromRaw(state)
       );
-      expect(stateToHTML(contentState)).toBe(html);
+      expect(stateToHTML(contentState, customStyles)).toBe(html);
     });
   });
 });

--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -29,3 +29,11 @@
   <li>One</li>
   <li>Two</li>
 </ol>
+
+# Single custom style
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BLUE_ON_RED"}],"entityRanges":[]}]}
+<p>asd<span style="color: blue; background-color: red">f</span></p>
+
+# Nested custom styles
+{"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":10,"style":"BLUE_ON_RED"},{"offset":0,"length":10,"style":"UPPERCASE"}],"entityRanges":[]}]}
+<p><span style="text-transform: uppercase"><span style="color: blue; background-color: red">BoldItalic</span></span></p>


### PR DESCRIPTION
Enable export of ContentState instances that contain custom style keys (i.e. when using the customStyleMap as described here: https://facebook.github.io/draft-js/docs/advanced-topics-inline-styles.html#content).
