### PR TITLE
Ignore log files and add watch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _*
 !__tests__
 /lib
 /node_modules
+*.log
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "typecheck": "flow",
     "prepublish": "npm run build",
     "test": "npm run lint && npm run typecheck && npm run test-src",
-    "test-src": "mocha src/__tests__/*.js src/**/__tests__/*.js"
+    "test-src": "mocha src/__tests__/*.js src/**/__tests__/*.js",
+    "watch": "npm run build -- --watch"
   },
   "dependencies": {
     "draft-js-utils": "^0.1.4"


### PR DESCRIPTION
Two small changes to improve DX:
- Git-ignore `*.log` (`npm-debug.log`, I'm looking at you!)
- Add a `npm run watch` script that simply passes `--watch` to `babel` via the normal `npm run build` script.
