### PR TITLE
Don't self-close BREAK tag

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -23,7 +23,7 @@ const {
 } = INLINE_STYLE;
 
 const INDENT = '  ';
-const BREAK = '<br/>';
+const BREAK = '<br>';
 
 // Map entity data to element attributes.
 const ENTITY_ATTR_MAP: AttrMap = {


### PR DESCRIPTION
- In  HTML5, `<br>` is a void tag, without an end tag.
- Unless we're going for XHTML compatibility, using `<br>` without self-closing `/` seems the more common approach.
- http://stackoverflow.com/a/1946446
