### PR TITLE
Allow custom inline tags in `options` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,26 @@ It was extracted from [React-RTE](https://react-rte.org) and placed into a separ
 
 ## How to Use
 
-    import {stateToHTML} from 'draft-js-export-html';
-    let html = stateToHTML(contentState);
+```js
+import {stateToHTML} from 'draft-js-export-html';
+let html = stateToHTML(contentState);
+```
 
 This project is still under development. If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).
+
+### Options
+
+You can optionally pass a second `Object` argument to `stateToHTML` with the following supported properties:
+
+#### `inlineTags`
+
+You can define custom inline tags to use for specific styles; e.g. `<b>` instead of `<strong>` for `BOLD`:
+
+```js
+import {stateToHTML} from 'draft-js-export-html';
+let options = {inlineTags: {BOLD: 'b'}};
+let HTML = stateToHTML(contentState);
+```
 
 ## License
 

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -14,6 +14,11 @@ let testCasesRaw = fs.readFileSync(
   'utf8',
 );
 
+let testCasesCustomRaw = fs.readFileSync(
+  join(__dirname, '..', '..', 'test', 'test-cases-custom.txt'),
+  'utf8',
+);
+
 let testCases = testCasesRaw.slice(1).trim().split(SEP).map((text) => {
   let lines = text.split('\n');
   let description = lines.shift().trim();
@@ -22,14 +27,38 @@ let testCases = testCasesRaw.slice(1).trim().split(SEP).map((text) => {
   return {description, state, html};
 });
 
+let testCasesCustom = testCasesCustomRaw.slice(1).trim().split(SEP).map((text) => {
+  let lines = text.split('\n');
+  let description = lines.shift().trim();
+  let options = JSON.parse(lines[0]);
+  let state = JSON.parse(lines[1]);
+  let html = lines.slice(2).join('\n');
+  return {description, options, state, html};
+});
+
 describe('stateToHTML', () => {
-  testCases.forEach((testCase) => {
-    let {description, state, html} = testCase;
-    it(`should render ${description}`, () => {
-      let contentState = ContentState.createFromBlockArray(
-        convertFromRaw(state)
-      );
-      expect(stateToHTML(contentState)).toBe(html);
+  describe('basic test cases', () => {
+    testCases.forEach((testCase) => {
+      let {description, state, html} = testCase;
+      it(`should render ${description}`, () => {
+        let contentState = ContentState.createFromBlockArray(
+          convertFromRaw(state)
+        );
+        expect(stateToHTML(contentState)).toBe(html);
+      });
     });
   });
+
+  describe('Custom inline tags', () => {
+    testCasesCustom.forEach((testCase) => {
+      let {description, options, state, html} = testCase;
+      it(`should render ${description}`, () => {
+        let contentState = ContentState.createFromBlockArray(
+          convertFromRaw(state)
+        );
+        expect(stateToHTML(contentState, options)).toBe(html);
+      });
+    });
+  });
+
 });

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -11,8 +11,12 @@ import {
 import type {ContentState, ContentBlock, EntityInstance} from 'draft-js';
 import type {CharacterMetaList} from 'draft-js-utils';
 
+type InlineTagMap = {[key: string]: string};
 type StringMap = {[key: string]: ?string};
 type AttrMap = {[key: string]: StringMap};
+type Options = {
+  inlineTags?: InlineTagMap;
+};
 
 const {
   BOLD,
@@ -61,6 +65,15 @@ const DATA_TO_ATTR = {
   },
 };
 
+// Map style to HTML tag
+const INLINE_STYLE_TO_TAG = {
+  [BOLD]: 'strong',
+  [CODE]: 'code',
+  [ITALIC]: 'em',
+  [STRIKETHROUGH]: 'del',
+  [UNDERLINE]: 'ins',
+};
+
 // The reason this returns an array is because a single block might get wrapped
 // in two tags.
 function getTags(blockType: string): Array<string> {
@@ -105,12 +118,14 @@ class MarkupGenerator {
   contentState: ContentState;
   currentBlock: number;
   indentLevel: number;
+  options: ?Options;
   output: Array<string>;
   totalBlocks: number;
   wrapperTag: ?string;
 
-  constructor(contentState: ContentState) {
+  constructor(contentState: ContentState, options: ?Options = {}) {
     this.contentState = contentState;
+    this.options = options;
   }
 
   generate(): string {
@@ -220,6 +235,9 @@ class MarkupGenerator {
   }
 
   renderBlockContent(block: ContentBlock): string {
+    let {options} = this;
+    // Flow doesn't care that `options` has a default value in `constructor`.
+    let inlineTags = options ? options.inlineTags : null;
     let blockType = block.getType();
     let text = block.getText();
     if (text === '') {
@@ -229,26 +247,26 @@ class MarkupGenerator {
     text = this.preserveWhitespace(text);
     let charMetaList: CharacterMetaList = block.getCharacterList();
     let entityPieces = getEntityRanges(text, charMetaList);
+    // Merge core tag map with user provided map
+    let tagMap = {
+      ...INLINE_STYLE_TO_TAG,
+      ...inlineTags,
+    };
     return entityPieces.map(([entityKey, stylePieces]) => {
       let content = stylePieces.map(([text, style]) => {
         let content = encodeContent(text);
-        // These are reverse alphabetical by tag name.
-        if (style.has(BOLD)) {
-          content = `<strong>${content}</strong>`;
-        }
-        if (style.has(UNDERLINE)) {
-          content = `<ins>${content}</ins>`;
-        }
-        if (style.has(ITALIC)) {
-          content = `<em>${content}</em>`;
-        }
-        if (style.has(STRIKETHROUGH)) {
-          content = `<del>${content}</del>`;
-        }
+        let styleTypes = Object.keys(tagMap);
+        styleTypes.forEach((styleType) => {
+          if (styleType !== CODE && style.has(styleType)) {
+            content = `<${tagMap[styleType]}>${content}</${tagMap[styleType]}>`;
+          }
+        });
         if (style.has(CODE)) {
           // If our block type is CODE then we are already wrapping the whole
           // block in a `<code>` so don't wrap inline code elements.
-          content = (blockType === BLOCK_TYPE.CODE) ? content : `<code>${content}</code>`;
+          content = (blockType === BLOCK_TYPE.CODE) ?
+          content :
+          `<${tagMap[CODE]}>${content}</${tagMap[CODE]}>`;
         }
         return content;
       }).join('');
@@ -328,6 +346,6 @@ function encodeAttr(text: string): string {
     .split('"').join('&quot;');
 }
 
-export default function stateToHTML(content: ContentState): string {
-  return new MarkupGenerator(content).generate();
+export default function stateToHTML(content: ContentState, options: ?Options): string {
+  return new MarkupGenerator(content, options).generate();
 }

--- a/test/test-cases-custom.txt
+++ b/test/test-cases-custom.txt
@@ -1,0 +1,24 @@
+# Custom BOLD tag
+{"inlineTags":{"BOLD": "b"}}
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
+<p>asd<b>f</b></p>
+
+# Custom ITALIC tag
+{"inlineTags":{"ITALIC": "i"}}
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"ITALIC"}],"entityRanges":[]}]}
+<p>asd<i>f</i></p>
+
+# Custom UNDERLINE tag
+{"inlineTags":{"UNDERLINE": "u"}}
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"UNDERLINE"}],"entityRanges":[]}]}
+<p>asd<u>f</u></p>
+
+# Custom STRIKETHROUGH tag
+{"inlineTags":{"STRIKETHROUGH": "s"}}
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"STRIKETHROUGH"}],"entityRanges":[]}]}
+<p>asd<s>f</s></p>
+
+# Custom CODE tag
+{"inlineTags":{"CODE": "pre"}}
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"CODE"}],"entityRanges":[]}]}
+<p>asd<pre>f</pre></p>


### PR DESCRIPTION
In the same vein as https://github.com/sstur/draft-js-import-element/pull/3, this change adds support for an `options` object where a consumer can define custom `inlineTags`.

_Example:_

``` js
import {stateToHTML} from 'draft-js-export-html';
let options = {inlineTags: {BOLD: 'b'}};
let HTML = stateToHTML(contentState);
```

I opted for creating a separate `test-cases-custom.txt` file to contain the option objects along with test cases.
