### PR TITLE
Use div instead p for the default unstyled element

### DIFF
--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -1,7 +1,7 @@
 /* @flow */
 const {describe, it} = global;
 import expect from 'expect';
-import {ContentState, convertFromRaw} from 'draft-js';
+import {convertFromRaw} from 'draft-js';
 import stateToHTML from '../stateToHTML';
 import fs from 'fs';
 import {join} from 'path';
@@ -26,10 +26,7 @@ describe('stateToHTML', () => {
   testCases.forEach((testCase) => {
     let {description, state, html} = testCase;
     it(`should render ${description}`, () => {
-      let contentState = ContentState.createFromBlockArray(
-        convertFromRaw(state)
-      );
-      expect(stateToHTML(contentState)).toBe(html);
+      expect(stateToHTML(convertFromRaw(state))).toBe(html);
     });
   });
 });

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -85,7 +85,7 @@ function getTags(blockType: string): Array<string> {
     case BLOCK_TYPE.CODE:
       return ['pre', 'code'];
     default:
-      return ['p'];
+      return ['div'];
   }
 }
 

--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -1,30 +1,30 @@
 # Plain text
 {"entityMap":{},"blocks":[{"key":"33nh8","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
-<p>a</p>
+<div>a</div>
 
 # Single inline style
 {"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
-<p>asd<strong>f</strong></p>
+<div>asd<strong>f</strong></div>
 
 # Nested inline styles
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":10,"style":"BOLD"},{"offset":0,"length":10,"style":"ITALIC"}],"entityRanges":[]}]}
-<p><em><strong>BoldItalic</strong></em></p>
+<div><em><strong>BoldItalic</strong></em></div>
 
 # Adjacent inline styles
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":4,"length":6,"style":"BOLD"},{"offset":0,"length":4,"style":"ITALIC"}],"entityRanges":[]}]}
-<p><em>Bold</em><strong>Italic</strong></p>
+<div><em>Bold</em><strong>Italic</strong></div>
 
 # Entity
 {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"/","rel":null,"title":"hi","extra":"foo"}}},"blocks":[{"key":"8r91j","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":1,"style":"ITALIC"}],"entityRanges":[{"offset":0,"length":1,"key":0}]}]}
-<p><a href="/" title="hi"><em>a</em></a></p>
+<div><a href="/" title="hi"><em>a</em></a></div>
 
 # Entity with inline style
 {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"/"}}},"blocks":[{"key":"8r91j","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":1,"style":"ITALIC"}],"entityRanges":[{"offset":0,"length":1,"key":0}]}]}
-<p><a href="/"><em>a</em></a></p>
+<div><a href="/"><em>a</em></a></div>
 
 # Ordered list
 {"entityMap":{},"blocks":[{"key":"33nh8","text":"An ordered list:","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
-<p>An ordered list:</p>
+<div>An ordered list:</div>
 <ol>
   <li>One</li>
   <li>Two</li>


### PR DESCRIPTION
The default unstyled element in draft is `div` instead of `p`. This is a quick-fix that fixes this. It should use the DefaultDraftBlockRenderMap instead (possibly with an option to specify the rendering of block types). Once #15 is done, I'd be willing to add support for it.

https://github.com/facebook/draft-js/blob/master/src/model/immutable/DefaultDraftBlockRenderMap.js#L62

Note: this was tested with Draft.js v0.7.0
