### PR TITLE
Add support for customStyleMap in options argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,31 @@ It was extracted from [React-RTE](https://react-rte.org) and placed into a separ
 
 ## How to Use
 
-    import {stateToHTML} from 'draft-js-export-html';
-    let html = stateToHTML(contentState);
+```javascript
+  import {stateToHTML} from 'draft-js-export-html';
+  let html = stateToHTML(contentState);
+```
+
+## Options
+
+`stateToHTML` accepts an optional options object as a second argument.
+
+| Option key     | Option Description   |
+| -------------- | -------------------- |
+| customStyleMap | Custom style mapping object, similar to the [customStyleMap](https://facebook.github.io/draft-js/docs/advanced-topics-inline-styles.html#mapping-a-style-string-to-css) the draft-js `Editor` receives.  |
+
+Example of options usage:
+
+```javascript
+  import {stateToHTML} from 'draft-js-export-html';
+  let options = {
+    customStyleMap: {
+      'RED': { color: 'red' }
+    }
+  };
+  let html = stateToHTML(contentState, options);
+```
+
 
 This project is still under development. If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example of options usage:
   import {stateToHTML} from 'draft-js-export-html';
   let options = {
     customStyleMap: {
-      'RED': { color: 'red' }
+      RED: { color: 'red' }
     }
   };
   let html = stateToHTML(contentState, options);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "watch": "npm run build -- --watch"
   },
   "dependencies": {
-    "draft-js-utils": "^0.1.5"
+    "draft-js-utils": "^0.1.5",
+    "fbjs": "^0.8.3"
   },
   "peerDependencies": {
     "draft-js": ">=0.6.0",

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -27,7 +27,8 @@ describe('stateToHTML', () => {
     let {description, state, html} = testCase;
     it(`should render ${description}`, () => {
       let contentState = convertFromRaw(state);
-      expect(stateToHTML(contentState)).toBe(html);
+      let options = {customStyleMap: {'RED': { color: 'red' }}};
+      expect(stateToHTML(contentState, options)).toBe(html);
     });
   });
 });

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -27,7 +27,7 @@ describe('stateToHTML', () => {
     let {description, state, html} = testCase;
     it(`should render ${description}`, () => {
       let contentState = convertFromRaw(state);
-      let options = {customStyleMap: {'RED': { color: 'red' }}};
+      let options = {customStyleMap: {RED: {color: 'red'}}};
       expect(stateToHTML(contentState, options)).toBe(html);
     });
   });

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -261,9 +261,9 @@ class MarkupGenerator {
           content = (blockType === BLOCK_TYPE.CODE) ? content : `<code>${content}</code>`;
         }
         // Apply custom styles supplied by the user
-        Object.keys(this.customStyleMap).forEach(key => {
+        Object.keys(this.customStyleMap).forEach((key) => {
           if (this.customStyleMap.hasOwnProperty(key) && style.has(key)) {
-              content = `<span style="${styleToCssString(this.customStyleMap[key])}">${content}</span>`;
+            content = `<span style="${styleToCssString(this.customStyleMap[key])}">${content}</span>`;
           }
         });
 

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -117,6 +117,7 @@ class MarkupGenerator {
   output: Array<string>;
   totalBlocks: number;
   wrapperTag: ?string;
+  customStyleMap: CustomStyleMap;
 
   constructor(contentState: ContentState, options: Options) {
     this.contentState = contentState;

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -7,6 +7,7 @@ import {
   ENTITY_TYPE,
   INLINE_STYLE,
 } from 'draft-js-utils';
+import styleToCssString from './styleToCssString';
 
 import type {ContentState, ContentBlock, EntityInstance} from 'draft-js';
 import type {CharacterMetaList} from 'draft-js-utils';
@@ -112,8 +113,9 @@ class MarkupGenerator {
   totalBlocks: number;
   wrapperTag: ?string;
 
-  constructor(contentState: ContentState) {
+  constructor(contentState: ContentState, options) {
     this.contentState = contentState;
+    this.customStyleMap = options.customStyleMap || {};
   }
 
   generate(): string {
@@ -253,6 +255,13 @@ class MarkupGenerator {
           // block in a `<code>` so don't wrap inline code elements.
           content = (blockType === BLOCK_TYPE.CODE) ? content : `<code>${content}</code>`;
         }
+        // Apply custom styles supplied by the user
+        Object.keys(this.customStyleMap).forEach(key => {
+          if (this.customStyleMap.hasOwnProperty(key) && style.has(key)) {
+              content = `<span style="${styleToCssString(this.customStyleMap[key])}">${content}</span>`;
+          }
+        });
+
         return content;
       }).join('');
       let entity = entityKey ? Entity.get(entityKey) : null;
@@ -332,6 +341,6 @@ function encodeAttr(text: string): string {
     .split('"').join('&quot;');
 }
 
-export default function stateToHTML(content: ContentState): string {
-  return new MarkupGenerator(content).generate();
+export default function stateToHTML(content: ContentState, options: ?Object): string {
+  return new MarkupGenerator(content, options || {}).generate();
 }

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -14,6 +14,11 @@ import type {CharacterMetaList} from 'draft-js-utils';
 
 type StringMap = {[key: string]: ?string};
 type AttrMap = {[key: string]: StringMap};
+type CustomStyleMap = {[styleName: string]: { [key: string]: string }};
+
+type Options = {
+  customStyleMap?: CustomStyleMap;
+};
 
 const {
   BOLD,
@@ -113,7 +118,7 @@ class MarkupGenerator {
   totalBlocks: number;
   wrapperTag: ?string;
 
-  constructor(contentState: ContentState, options) {
+  constructor(contentState: ContentState, options: Options) {
     this.contentState = contentState;
     this.customStyleMap = options.customStyleMap || {};
   }
@@ -341,6 +346,6 @@ function encodeAttr(text: string): string {
     .split('"').join('&quot;');
 }
 
-export default function stateToHTML(content: ContentState, options: ?Object): string {
+export default function stateToHTML(content: ContentState, options: ?Options): string {
   return new MarkupGenerator(content, options || {}).generate();
 }

--- a/src/styleToCssString.js
+++ b/src/styleToCssString.js
@@ -24,12 +24,13 @@ function buildRule(key, value) {
 
 export default function styleToCssString(rules) {
   let result = '';
+  let rulesKeys = keys(rules);
 
-  if (!rules || keys(rules).length === 0) {
+  if (!rules || rulesKeys.length === 0) {
     return result;
   }
 
-  let styleKeys = keys(rules);
+  let styleKeys = rulesKeys;
 
   for (var j = 0, l = styleKeys.length; j < l; j++) {
     let styleKey = styleKeys[j];

--- a/src/styleToCssString.js
+++ b/src/styleToCssString.js
@@ -1,0 +1,51 @@
+/**
+ * styleToCssString converts a react js style object to a css string value.
+ */
+
+import {isUnitlessNumber} from 'react/lib/CSSProperty';
+import hyphenateStyleName from 'fbjs/lib/hyphenateStyleName';
+
+const isArray = Array.isArray;
+const keys = Object.keys;
+
+let counter = 1;
+// Follows syntax at https://developer.mozilla.org/en-US/docs/Web/CSS/content,
+// including multiple space separated values.
+let unquotedContentValueRegex = /^(normal|none|(\b(url\([^)]*\)|chapter_counter|attr\([^)]*\)|(no-)?(open|close)-quote|inherit)((\b\s*)|$|\s+))+)$/;
+
+function buildRule(key, value) {
+  if (!isUnitlessNumber[key] && typeof value === 'number') {
+    value = '' + value + 'px';
+  }
+  else if (key === 'content' && !unquotedContentValueRegex.test(value)) {
+    value = "'" + value.replace(/'/g, "\\'") + "'";
+  }
+
+  return hyphenateStyleName(key) + ': ' + value + ';  ';
+}
+
+export default function styleToCssString(rules) {
+  let result = ''
+
+  if (!rules || keys(rules).length === 0) {
+    return result;
+  }
+
+  let styleKeys = keys(rules);
+
+  for (var j = 0, l = styleKeys.length; j < l; j++) {
+    let styleKey = styleKeys[j];
+    let value = rules[styleKey];
+
+    if (isArray(value)) {
+      for (let i = 0, len = value.length; i < len; i++) {
+          result += buildRule(styleKey, value[i]);
+      }
+    }
+    else {
+      result += buildRule(styleKey, value);
+    }
+  }
+
+  return result.trim();
+}

--- a/src/styleToCssString.js
+++ b/src/styleToCssString.js
@@ -8,7 +8,6 @@ import hyphenateStyleName from 'fbjs/lib/hyphenateStyleName';
 const isArray = Array.isArray;
 const keys = Object.keys;
 
-let counter = 1;
 // Follows syntax at https://developer.mozilla.org/en-US/docs/Web/CSS/content,
 // including multiple space separated values.
 let unquotedContentValueRegex = /^(normal|none|(\b(url\([^)]*\)|chapter_counter|attr\([^)]*\)|(no-)?(open|close)-quote|inherit)((\b\s*)|$|\s+))+)$/;
@@ -16,8 +15,7 @@ let unquotedContentValueRegex = /^(normal|none|(\b(url\([^)]*\)|chapter_counter|
 function buildRule(key, value) {
   if (!isUnitlessNumber[key] && typeof value === 'number') {
     value = '' + value + 'px';
-  }
-  else if (key === 'content' && !unquotedContentValueRegex.test(value)) {
+  } else if (key === 'content' && !unquotedContentValueRegex.test(value)) {
     value = "'" + value.replace(/'/g, "\\'") + "'";
   }
 
@@ -25,7 +23,7 @@ function buildRule(key, value) {
 }
 
 export default function styleToCssString(rules) {
-  let result = ''
+  let result = '';
 
   if (!rules || keys(rules).length === 0) {
     return result;
@@ -39,10 +37,9 @@ export default function styleToCssString(rules) {
 
     if (isArray(value)) {
       for (let i = 0, len = value.length; i < len; i++) {
-          result += buildRule(styleKey, value[i]);
+        result += buildRule(styleKey, value[i]);
       }
-    }
-    else {
+    } else {
       result += buildRule(styleKey, value);
     }
   }

--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -33,3 +33,7 @@
   <li>One</li>
   <li>Two</li>
 </ol>
+
+# Entity with a custom inline style
+{"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"/"}}},"blocks":[{"key":"8r91j","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":1,"style":"RED"}],"entityRanges":[{"offset":0,"length":1,"key":0}]}]}
+<p><a href="/"><span style="color: red;">a</span></a></p>


### PR DESCRIPTION
You can now optionally pass options argument containing a draft-js customStyleMap (like in [Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/color)).

I've updated the README file to explain the additional argument and how to use it.
I made sure all tests still pass.
I've added a new test that makes sure the new functionality works.

You can use the new parameter as following:

``` javascript
  import {stateToHTML} from 'draft-js-export-html';
  let options = {
    customStyleMap: {
      'RED': { color: 'red' }
    }
  };
  let html = stateToHTML(contentState, options);
```

And the result of a text with a "RED" style (in this case) will be: `<span style="color: red;">text</span>` (can be seen in the tests).
