### PR TITLE
Support custom block renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,29 @@ let options = {
 let html = stateToHTML(contentState, options);
 ```
 
+### `blockRenderers`
 
-This project is still under development. If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).
+You can define a custom renderer for any block type. Pass a function that accepts `block` as an argument. You can return a string to render this block yourself, or return nothing (null or undefined) to defer to the default renderer.
+
+Example:
+
+```javascript
+let options = {
+  blockRenderers: {
+    ATOMIC: (block) => {
+      let data = block.getData();
+      if (data.foo === 'bar') {
+        return '<div>' + escape(block.getText()) + '</div>';
+      }
+    },
+  },
+};
+let html = stateToHTML(contentState, options);
+```
+
+## Contributing
+
+If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).
 
 ## License
 

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -53,4 +53,28 @@ describe('stateToHTML', () => {
       expect(stateToHTML(contentState, options)).toBe(html);
     });
   });
+
+  it('should support custom block renderer', () => {
+    let options = {
+      blockRenderers: {
+        'code-block': (block) => {
+          return `<div class="code">${block.getText()}</div>`;
+        },
+      },
+    };
+    let contentState = convertFromRaw(
+      // <pre><code>Hello <em>world</em>.</code></pre>
+      {"entityMap":{},"blocks":[{"key":"dn025","text":"Hello world.","type":"code-block","depth":0,"inlineStyleRanges":[{"offset":6,"length":5,"style":"ITALIC"}],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState, options)).toBe(
+      '<div class="code">Hello world.</div>'
+    );
+    let contentState2 = convertFromRaw(
+      // <h1>Hello <em>world</em>.</h1>
+      {"entityMap":{},"blocks":[{"key":"dn025","text":"Hello world.","type":"header-one","depth":0,"inlineStyleRanges":[{"offset":6,"length":5,"style":"ITALIC"}],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState2, options)).toBe(
+      '<h1>Hello <em>world</em>.</h1>'
+    );
+  });
 });


### PR DESCRIPTION
This feature is inspired by #8 by @mikejoseph. It allows you to pass a custom renderer for any block type.

It works like this:

``` javascript
let options = {
  blockRenderers: {
    ATOMIC: (block) => {
      let data = Entity.get(block.getEntityAt(0)).getData();
      if (data.type === 'pull-quote') {
        return '<div>' + escape(data.content) + '</div>';
      }
    },
  },
};
let html = stateToHTML(contentState, options);
```
