### PR TITLE
Allow custom getTags and getWrapperTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,71 @@ let options = {
 let html = stateToHTML(contentState, options);
 ```
 
+### `blockTags`
+
+You can define custom block tags for specific types. Pass a function that accepts `blockType` as an argument. You may want to use this over `blockRenderers` when you want all the default processing of attributes, styles, etc... but want to simply use a different tag for a block type. The reason this returns an array is because a single block might get wrapped in two tags.
+
+Example:
+
+```javascript
+import { BLOCK_TYPE } from 'draft-js-utils';
+
+let options = {
+  blockTags: function(blockType) {
+    switch (blockType) {
+      case BLOCK_TYPE.HEADER_ONE:
+        return ['h1'];
+      case BLOCK_TYPE.HEADER_TWO:
+        return ['h2'];
+      case BLOCK_TYPE.HEADER_THREE:
+        return ['h3'];
+      case BLOCK_TYPE.HEADER_FOUR:
+        return ['h4'];
+      case BLOCK_TYPE.HEADER_FIVE:
+        return ['h5'];
+      case BLOCK_TYPE.HEADER_SIX:
+        return ['h6'];
+      case BLOCK_TYPE.UNORDERED_LIST_ITEM:
+      case BLOCK_TYPE.ORDERED_LIST_ITEM:
+        return ['li'];
+      case BLOCK_TYPE.BLOCKQUOTE:
+        return ['blockquote'];
+      case BLOCK_TYPE.CODE:
+        return ['pre', 'code'];
+      case BLOCK_TYPE.ATOMIC:
+        return ['figure'];
+      default:
+        return ['p'];
+    }
+  },
+};
+let html = stateToHTML(contentState, options);
+```
+
+### `blockWrapperTag`
+
+You can specify custom block wrapper tags. Pass a function that accepts `blockType` as an argument. You can return a string or null.
+
+Example:
+
+```javascript
+import { BLOCK_TYPE } from 'draft-js-utils';
+
+let options = {
+  blockWrapperTag: function(blockType) {
+    switch (blockType) {
+      case BLOCK_TYPE.UNORDERED_LIST_ITEM:
+        return 'ul';
+      case BLOCK_TYPE.ORDERED_LIST_ITEM:
+        return 'ol';
+      default:
+        return null;
+    }
+  },
+};
+let html = stateToHTML(contentState, options);
+```
+
 ## Contributing
 
 If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -77,4 +77,68 @@ describe('stateToHTML', () => {
       '<h1>Hello <em>world</em>.</h1>'
     );
   });
+
+  it('should support custom tags', () => {
+    let options = {
+      blockTags(blockType) {
+        switch (blockType) {
+          case 'blockquote':
+            return ['p'];
+          default:
+            return ['span'];
+        }
+      },
+    };
+    let contentState = convertFromRaw(
+        // <h1>Hello <em>world</em>.</h1>
+        {"entityMap":{},"blocks":[{"key":"dn025","text":"Hello world.","type":"header-one","depth":0,"inlineStyleRanges":[{"offset":6,"length":5,"style":"ITALIC"}],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState, options)).toBe(
+        '<span>Hello <em>world</em>.</span>'
+    );
+    let contentState2 = convertFromRaw(
+        // <blockquote>Hello <em>world</em>.</blockquote>
+        {"entityMap":{},"blocks":[{"key":"dn025","text":"Hello world.","type":"blockquote","depth":0,"inlineStyleRanges":[{"offset":6,"length":5,"style":"ITALIC"}],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState2, options)).toBe(
+        '<p>Hello <em>world</em>.</p>'
+    );
+  });
+
+  it('should support custom wrapper tag', () => {
+    let options = {
+      blockWrapperTag(blockType) {
+        switch (blockType) {
+          case 'unordered-list-item':
+            return 'ol';
+          default:
+            return 'ul';
+        }
+      },
+    };
+    let contentState = convertFromRaw(
+        /*
+         <ol>
+           <li>One</li>
+           <li>Two</li>
+         </ol>
+         */
+        {"entityMap":{},"blocks":[{"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState, options)).toBe(
+        '<ul>\n  <li>One</li>\n  <li>Two</li>\n</ul>'
+    );
+    let contentState2 = convertFromRaw(
+        /*
+         <ul>
+           <li>One</li>
+           <li>Two</li>
+         </ul>
+         */
+        {"entityMap":{},"blocks":[{"key":"8kinl","text":"One","type":"unordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"unordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState2, options)).toBe(
+        '<ol>\n  <li>One</li>\n  <li>Two</li>\n</ol>'
+    );
+  });
 });


### PR DESCRIPTION
This feature allows you to specify custom methods for `getTags` and `getWrapperTag`
#### Why not use `blockRenderer`?

This would work but I want to take advantage of [renderBlockContent](https://github.com/sstur/draft-js-export-html/blob/8b874c8f246e5217be9969f977ae822e025bbeb5/src/stateToHTML.js#L290-L340). Specifically its style and attribute processing.
