### PR TITLE
Add support to render custom entities

### DIFF
--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -77,4 +77,26 @@ describe('stateToHTML', () => {
       '<h1>Hello <em>world</em>.</h1>'
     );
   });
+
+  it('should support custom entities renderer', () => {
+    let options = {
+      entityRenderers: {
+        COLOR: {
+          attributeMap: {color: 'color'},
+          render: (attrs, content) => {
+            const {color} = attrs;
+
+            return `<span style="color: ${color}">${content}</span>`;
+          },
+        },
+      },
+    };
+    let contentState = convertFromRaw(
+      //<span style="color: #f40000"><h2>red</h2></span>
+      {"entityMap":{"0":{"type":"COLOR","mutability":"MUTABLE","data":{"color":"#f40000"}}},"blocks":[{"key":"16bo7","text":"Red","type":"header-two","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":0,"length":3,"key":0}]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState, options)).toBe(
+      '<h2><span style="color: #f40000">Red</span></h2>'
+    );
+  });
 });


### PR DESCRIPTION
Inspired by #21 

This allows you to add custom renderers for entities like:

``` js
let options = {
  entityRenderers: {
    COLOR: {
       attributeMap: {color: 'color'},
       render: (({color}), content) => {
            return `<span style="color: ${color}">${content}</span>`;
        },
     },
  },
};
let html = stateToHTML(contentState, options);
```

I have adjusted the existing `LINK` and `IMAGE` entities to use this new format.
