### PR TITLE
Support last draft.js

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -170,7 +170,7 @@ class MarkupGenerator {
 
   generate(): string {
     this.output = [];
-    this.blocks = this.contentState.getBlocksAsArray();
+    this.blocks = this.contentState.getCurrentContent().getBlocksAsArray();
     this.totalBlocks = this.blocks.length;
     this.currentBlock = 0;
     this.indentLevel = 0;


### PR DESCRIPTION
`stateToHTML.js:204   Uncaught TypeError: this.contentState.getBlocksAsArray is not a function`

->

`this.contentState.getCurrentContent().getBlocksAsArray()`
