### PR TITLE
Add blockStyleFn for arbitrary styles and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,33 @@ let options = {
 let html = stateToHTML(contentState, options);
 ```
 
+### `blockStyleFn`
+
+You can define custom styles and attributes for your block, utilizing the underlying built-in rendering logic of the tags, but adding your own attributes or styles on top. The `blockStyleFn` option takes a block and returns an Object similar to `inlineStyles` of the following signature or null:
+
+```js
+{
+  attributes: {}
+  style: {}
+}
+```
+
+Example:
+```js
+let options = {
+  blockStyleFn(block) => {
+    if (block.getData().get('color')) {
+      return {
+        style: {
+          color: block.getData().get('color')
+        }
+      }
+    }
+  }
+}
+let html = stateToHTML(contentState, options);
+```
+
 ## Contributing
 
 If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "draft-js-utils": "^0.1.5"
   },
   "peerDependencies": {
-    "draft-js": ">=0.6.0",
+    "draft-js": ">=0.8.0",
     "immutable": "3.x.x"
   },
   "devDependencies": {

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -77,4 +77,32 @@ describe('stateToHTML', () => {
       '<h1>Hello <em>world</em>.</h1>'
     );
   });
+
+  it('should support custom block styles', () => {
+    let options = {
+      blockStyleFn: (block) => {
+        if (block.getData().get('alignment')) {
+          return {
+            style: {
+              textAlign: block.getData().get('alignment')
+            }
+          };
+        }
+      }
+    };
+    let contentState1 = convertFromRaw(
+      // <h1 style="text-align: left;">Hello <em>world</em>.</h1>
+      {"entityMap":{},"blocks":[{"data":{"alignment":"left"},"key":"dn025","text":"Hello world.","type":"header-one","depth":0,"inlineStyleRanges":[{"offset":6,"length":5,"style":"ITALIC"}],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState1, options)).toBe(
+      '<h1 style="text-align: left">Hello <em>world</em>.</h1>'
+    );
+    let contentState2 = convertFromRaw(
+      // <h1>Hello <em>world</em>.</h1>
+      {"entityMap":{},"blocks":[{"key":"dn025","text":"Hello world.","type":"header-one","depth":0,"inlineStyleRanges":[{"offset":6,"length":5,"style":"ITALIC"}],"entityRanges":[]}]} // eslint-disable-line
+    );
+    expect(stateToHTML(contentState2, options)).toBe(
+      '<h1>Hello <em>world</em>.</h1>'
+    );
+  });
 });

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -19,10 +19,13 @@ type AttrMap = {[key: string]: string};
 type Attributes = {[key: string]: string};
 type StyleDescr = {[key: string]: number | string};
 
-type RenderConfig = {
-  element?: string;
+interface AttributesConfig {
   attributes?: Attributes;
   style?: StyleDescr;
+}
+
+interface RenderConfig extends AttributesConfig {
+  element?: string;
 };
 
 type BlockRenderer = (block: ContentBlock) => ?string;
@@ -30,9 +33,12 @@ type BlockRendererMap = {[blockType: string]: BlockRenderer};
 
 type StyleMap = {[styleName: string]: RenderConfig};
 
+type BlockStyleFn = (block: ContentBlock) => ?RenderConfig;
+
 type Options = {
   inlineStyles?: StyleMap;
   blockRenderers?: BlockRendererMap;
+  blockStyleFn?: BlockStyleFn;
 };
 
 const {
@@ -208,7 +214,7 @@ class MarkupGenerator {
       this.currentBlock += 1;
       return;
     }
-    this.writeStartTag(blockType);
+    this.writeStartTag(block);
     this.output.push(this.renderBlockContent(block));
     // Look ahead and see if we will nest list.
     let nextBlock = this.getNextBlock();
@@ -231,7 +237,7 @@ class MarkupGenerator {
     } else {
       this.currentBlock += 1;
     }
-    this.writeEndTag(blockType);
+    this.writeEndTag(block);
   }
 
   processBlocksAtDepth(depth: number) {
@@ -247,15 +253,30 @@ class MarkupGenerator {
     return this.blocks[this.currentBlock + 1];
   }
 
-  writeStartTag(blockType) {
-    let tags = getTags(blockType);
+  writeStartTag(block) {
+    let tags = getTags(block.getType());
+
+    let attrString;
+    if (this.options.blockStyleFn) {
+      let { attributes, style } = this.options.blockStyleFn(block) || {};
+      // Normalize `className` -> `class`, etc.
+      attributes = normalizeAttributes(attributes);
+      if (style != null) {
+        let styleAttr = styleToCSS(style);
+        attributes = (attributes == null) ? {style: styleAttr} : {...attributes, style: styleAttr};
+      }
+      attrString = stringifyAttrs(attributes);
+    } else {
+      attrString = '';
+    }
+
     for (let tag of tags) {
-      this.output.push(`<${tag}>`);
+      this.output.push(`<${tag}${attrString}>`)
     }
   }
 
-  writeEndTag(blockType) {
-    let tags = getTags(blockType);
+  writeEndTag(block) {
+    let tags = getTags(block.getType());
     if (tags.length === 1) {
       this.output.push(`</${tags[0]}>\n`);
     } else {


### PR DESCRIPTION
We're utilizing DraftJS 0.8.0's new content block data feature that allows you to attach arbitrary data to each content block. We use this to add text alignment to the block, so we needed a way to render that.

This feature adds a new option (non-breaking change) called `blockStyleFn` that takes a content block and optionally returns a map of styles and attributes to be added the rendered tag.
## Future Work

We should probably change `inlineStyles` and `blockRenderer` to work in a similar fashion, simply being a function that takes a block (or entity) rather than a map of block types (or entity types) to styles. This makes the customization much more flexible.

I avoided making this change for now since it would be a breaking change, but certainly willing to help out if we want to do it.
