### PR TITLE
moved Entity into contentState

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -341,7 +341,7 @@ class MarkupGenerator {
         }
         return content;
       }).join('');
-      let entity = entityKey ? Entity.get(entityKey) : null;
+      let entity = entityKey ? this.contentState.getEntity(entityKey) : null;
       // Note: The `toUpperCase` below is for compatability with some libraries that use lower-case for image blocks.
       let entityType = (entity == null) ? null : entity.getType().toUpperCase();
       if (entityType != null && entityType === ENTITY_TYPE.LINK) {


### PR DESCRIPTION
DraftJS team moved Entity methods into content state

https://github.com/facebook/draft-js/commit/5d5f1b4b89c509d17697965ce9a0d596ed220c43

I was getting error on current "Entity.get"
