### PR TITLE
Typescript Typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.1",
   "description": "DraftJS: Export ContentState to HTML",
   "main": "lib/main.js",
+  "typings": "typings/intex.d.ts",
   "scripts": {
     "build": "babel src --ignore \"_*\" --out-dir lib",
     "lint": "eslint --max-warnings 0 .",
@@ -20,6 +21,7 @@
     "immutable": "3.x.x"
   },
   "devDependencies": {
+    "@types/draft-js": "^0.7.33",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.9.1",
     "babel-eslint": "^7.0.0",

--- a/typings/draft-js-export-html-tests.ts
+++ b/typings/draft-js-export-html-tests.ts
@@ -1,0 +1,28 @@
+import {EditorState, ContentBlock} from 'draft-js';
+import {stateToHTML} from 'draft-js-export-html';
+
+const state = EditorState.createEmpty();
+
+let res: string = stateToHTML(state);
+res = stateToHTML(state, {
+    inlineStyles: {
+        // Override default element (`strong`).
+        BOLD: {element: 'b'},
+        ITALIC: {
+            // Add custom attributes. You can also use React-style `className`.
+            attributes: {class: 'foo'},
+            // Use camel-case. Units (`px`) will be added where necessary.
+            style: {fontSize: 12}
+        },
+        // Use a custom inline style. Default element is `span`.
+        RED: {style: {color: '#900'}},
+    },
+});
+res = stateToHTML(state, {
+    blockRenderers: {
+        ATOMIC: (block) => {
+            let data = block.getData();
+            return data.toString();
+        },
+    },
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,21 @@
+/// <reference types="draft-js" />
+
+declare module 'draft-js-export-html' {
+    import draftjs = require("draft-js");
+
+    type BlockStyleFn = (block: draftjs.ContentBlock) => any;
+    type BlockRenderer = (block: draftjs.ContentBlock) => string;
+    type RenderConfig = {
+        element?: string;
+        attributes?: any;
+        style?: any;
+    };
+
+    export interface Options {
+        inlineStyles?: { [styleName: string]: RenderConfig };
+        blockRenderers?: { [blockType: string]: BlockRenderer };
+        blockStyleFn?: BlockStyleFn;
+    }
+
+    export function stateToHTML(content: draftjs.EditorState, options?: Options): string;
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": true,
+    "strictNullChecks": false,
+    "baseUrl": "./",
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "draft-js-export-html-tests.ts"
+  ]
+}


### PR DESCRIPTION
These are typescript typings which make the lib work in a typescript environment. 

*typings* directory should be publish to npm along with the *lib* directory. It contains typings - *index.d.ts* and usage example *draft-js-export-html-tests.ts*.

To validate the typings, typescript should be installed globally (npm install -g typescript@2.0), then cd to *./typings* and  run `tsc` ,