### PR TITLE
Adding additional styling options for wrapper elements and existent entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ _*
 /lib
 /node_modules
 *.log
+.idea
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,55 @@ let options = {
 let html = stateToHTML(contentState, options);
 ```
 
+
+### `entityStyles`
+
+You can define any additional attributes for supported entities: LINK and IMAGE.
+
+Example:
+
+```javascript
+let options = {
+  entityStyles: {
+    LINK: {
+      attributes: {
+        class: 'entity entity--link',
+        target: '_blank',
+      }
+    }
+  },
+};
+let html = stateToHTML(contentState, options);
+```
+
+### `wrapperStyles`
+
+You can define additional attributes to lists wrappers.
+
+Example:
+
+```javascript
+let options = {
+  wrapperStyles: {
+    ul: {
+      attributes: {
+        class: 'block block--ul'
+      }
+    },
+    ol: {
+      attributes: {
+        class: 'block block--ol'
+      }
+    }
+  },
+};
+let html = stateToHTML(contentState, options);
+```
+
+
+
+
+
 ### `blockStyleFn`
 
 You can define custom styles and attributes for your block, utilizing the underlying built-in rendering logic of the tags, but adding your own attributes or styles on top. The `blockStyleFn` option takes a block and returns an Object similar to `inlineStyles` of the following signature or null:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "typings": "typings/index.d.ts",
   "scripts": {
-    "build": "babel src --ignore \"_*\" --out-dir lib",
+    "build": "babel src --ignore \"_*\" --out-dir ../Stewie/node_modules/draft-js-export-html/lib",
     "lint": "eslint --max-warnings 0 .",
     "typecheck": "flow",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "draft-js-export-html",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "DraftJS: Export ContentState to HTML",
   "main": "lib/main.js",
   "typings": "typings/index.d.ts",
   "scripts": {
-    "build": "babel src --ignore \"_*\" --out-dir ../Stewie/node_modules/draft-js-export-html/lib",
+    "build": "babel src --ignore \"_*\" --out-dir lib",
     "lint": "eslint --max-warnings 0 .",
     "typecheck": "flow",
     "prepublish": "npm run build",

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -186,7 +186,7 @@ class MarkupGenerator {
   }
 
   processBlock() {
-    let {blockRenderers} = this.options;
+    let {blockRenderers } = this.options;
     let block = this.blocks[this.currentBlock];
     let blockType = block.getType();
     let newWrapperTag = getWrapperTag(blockType);
@@ -212,6 +212,7 @@ class MarkupGenerator {
       return;
     }
     this.writeStartTag(block);
+
     this.output.push(this.renderBlockContent(block));
     // Look ahead and see if we will nest list.
     let nextBlock = this.getNextBlock();
@@ -286,9 +287,11 @@ class MarkupGenerator {
   }
 
   openWrapperTag(wrapperTag: string) {
+    let { wrapperStyles } = this.options
+    let attrs = wrapperStyles && wrapperStyles[wrapperTag] && wrapperStyles[wrapperTag].attributes || {}
     this.wrapperTag = wrapperTag;
     this.indent();
-    this.output.push(`<${wrapperTag}>\n`);
+    this.output.push(`<${wrapperTag}${stringifyAttrs(attrs)}>\n`);
     this.indentLevel += 1;
   }
 
@@ -344,13 +347,16 @@ class MarkupGenerator {
       let entity = entityKey ? Entity.get(entityKey) : null;
       // Note: The `toUpperCase` below is for compatability with some libraries that use lower-case for image blocks.
       let entityType = (entity == null) ? null : entity.getType().toUpperCase();
+      let { entityStyles } = this.options;
       if (entityType != null && entityType === ENTITY_TYPE.LINK) {
         let attrs = DATA_TO_ATTR.hasOwnProperty(entityType) ? DATA_TO_ATTR[entityType](entityType, entity) : null;
-        let attrString = stringifyAttrs(attrs);
+        let additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
+        let attrString = stringifyAttrs({ ...attrs, ...normalizeAttributes(additionalAttrs) });
         return `<a${attrString}>${content}</a>`;
       } else if (entityType != null && entityType === ENTITY_TYPE.IMAGE) {
         let attrs = DATA_TO_ATTR.hasOwnProperty(entityType) ? DATA_TO_ATTR[entityType](entityType, entity) : null;
-        let attrString = stringifyAttrs(attrs);
+        let additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
+        let attrString = stringifyAttrs({ ...attrs, ...normalizeAttributes(additionalAttrs) });
         return `<img${attrString}/>`;
       } else {
         return content;

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -186,7 +186,7 @@ class MarkupGenerator {
   }
 
   processBlock() {
-    let {blockRenderers } = this.options;
+    let {blockRenderers} = this.options;
     let block = this.blocks[this.currentBlock];
     let blockType = block.getType();
     let newWrapperTag = getWrapperTag(blockType);
@@ -291,7 +291,7 @@ class MarkupGenerator {
     let attrs = wrapperStyles && wrapperStyles[wrapperTag] && wrapperStyles[wrapperTag].attributes || {}
     this.wrapperTag = wrapperTag;
     this.indent();
-    this.output.push(`<${wrapperTag}${stringifyAttrs(attrs)}>\n`);
+    this.output.push(`<${wrapperTag}${stringifyAttrs(normalizeAttributes(attrs))}>\n`);
     this.indentLevel += 1;
   }
 

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -344,24 +344,27 @@ class MarkupGenerator {
         }
         return content;
       }).join('');
+
       let entity = entityKey ? Entity.get(entityKey) : null;
       // Note: The `toUpperCase` below is for compatability with some libraries that use lower-case for image blocks.
       let entityType = (entity == null) ? null : entity.getType().toUpperCase();
-      let { entityStyles } = this.options;
       if (entityType != null && entityType === ENTITY_TYPE.LINK) {
-        let attrs = DATA_TO_ATTR.hasOwnProperty(entityType) ? DATA_TO_ATTR[entityType](entityType, entity) : null;
-        let additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
-        let attrString = stringifyAttrs({ ...attrs, ...normalizeAttributes(additionalAttrs) });
+        let attrString = this.getAttributesWithEntityStyles(entityType, entity);
         return `<a${attrString}>${content}</a>`;
       } else if (entityType != null && entityType === ENTITY_TYPE.IMAGE) {
-        let attrs = DATA_TO_ATTR.hasOwnProperty(entityType) ? DATA_TO_ATTR[entityType](entityType, entity) : null;
-        let additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
-        let attrString = stringifyAttrs({ ...attrs, ...normalizeAttributes(additionalAttrs) });
+        let attrString = this.getAttributesWithEntityStyles(entityType, entity);
         return `<img${attrString}/>`;
       } else {
         return content;
       }
     }).join('');
+  }
+
+  getAttributesWithEntityStyles(entityType: string, entity: Entity): string {
+    let { entityStyles } = this.options;
+    let attrs = DATA_TO_ATTR.hasOwnProperty(entityType) ? DATA_TO_ATTR[entityType](entityType, entity) : null;
+    let additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
+    return stringifyAttrs({ ...attrs, ...normalizeAttributes(additionalAttrs) });
   }
 
   preserveWhitespace(text: string): string {

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -361,9 +361,9 @@ class MarkupGenerator {
   }
 
   getAttributesWithEntityStyles(entityType: string, entity: Entity): string {
-    let { entityStyles } = this.options;
-    let attrs = DATA_TO_ATTR.hasOwnProperty(entityType) ? DATA_TO_ATTR[entityType](entityType, entity) : null;
-    let additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
+    const { entityStyles } = this.options;
+    const attrs = DATA_TO_ATTR.hasOwnProperty(entityType) && DATA_TO_ATTR[entityType](entityType, entity);
+    const additionalAttrs = entityStyles && entityStyles[entityType] && entityStyles[entityType].attributes || {}
     return stringifyAttrs({ ...attrs, ...normalizeAttributes(additionalAttrs) });
   }
 


### PR DESCRIPTION
Hey, I've added support to passing attributes to entity wrappers "IMAGE and LINK" as well as to list wrappers.
I needed this in the project of mine for passing appropriate classNames when generating markup. 
I think it will be a good addition to the package and also will solve issues:

https://github.com/sstur/draft-js-export-html/issues/46
https://github.com/sstur/draft-js-export-html/issues/39

