### PR TITLE
Correct blockRenderers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Example:
 ```javascript
 let options = {
   blockRenderers: {
-    ATOMIC: (block) => {
+    atomic: (block) => {
       let data = block.getData();
       if (data.foo === 'bar') {
         return '<div>' + escape(block.getText()) + '</div>';


### PR DESCRIPTION
As mentioned [here](https://github.com/sstur/draft-js-export-html/issues/45#issuecomment-257874551) while working from this example I needed to change from `ATOMIC` to `atomic`.