### PR TITLE
Add "pretty printing" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
+    "draft-js": "^0.7.33",
     "eslint": "^3.7.1",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-flow-vars": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
-    "draft-js": "^0.7.33",
+    "draft-js": "^0.7.0",
     "eslint": "^3.7.1",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-flow-vars": "^0.5.0",

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -111,9 +111,17 @@ describe('stateToHTML', () => {
     );
   });
 
-  it('should support optional pretty-printing', () => {
+  it('should support optional pretty-printing unstyled text', () => {
     let contentState = convertFromRaw({"entityMap":{},"blocks":[{"key":"b4nv7","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"klgb","text":"b","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}); // eslint-disable-line
     expect(stateToHTML(contentState, {prettyPrint: true})).toBe('<p>a</p>\n<p>b</p>');
     expect(stateToHTML(contentState, {prettyPrint: false})).toBe('<p>a</p><p>b</p>');
+  })
+
+  it('should support optional pretty-printing lists', () => {
+    let contentState = convertFromRaw({"entityMap":{},"blocks":[{"key":"33nh8","text":"An ordered list:","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]});
+    expect(stateToHTML(contentState, {prettyPrint: true}))
+      .toBe('<p>An ordered list:</p>\n<ol>\n  <li>One</li>\n  <li>Two</li>\n</ol>');
+    expect(stateToHTML(contentState, {prettyPrint: false}))
+      .toBe('<p>An ordered list:</p><ol><li>One</li><li>Two</li></ol>');
   })
 });

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -118,7 +118,7 @@ describe('stateToHTML', () => {
   })
 
   it('should support optional pretty-printing lists', () => {
-    let contentState = convertFromRaw({"entityMap":{},"blocks":[{"key":"33nh8","text":"An ordered list:","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]});
+    let contentState = convertFromRaw({"entityMap":{},"blocks":[{"key":"33nh8","text":"An ordered list:","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}); // eslint-disable-line
     expect(stateToHTML(contentState, {prettyPrint: true}))
       .toBe('<p>An ordered list:</p>\n<ol>\n  <li>One</li>\n  <li>Two</li>\n</ol>');
     expect(stateToHTML(contentState, {prettyPrint: false}))

--- a/src/__tests__/stateToHTML-test.js
+++ b/src/__tests__/stateToHTML-test.js
@@ -110,4 +110,10 @@ describe('stateToHTML', () => {
       '<h1>Hello <em>world</em>.</h1>'
     );
   });
+
+  it('should support optional pretty-printing', () => {
+    let contentState = convertFromRaw({"entityMap":{},"blocks":[{"key":"b4nv7","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"klgb","text":"b","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}); // eslint-disable-line
+    expect(stateToHTML(contentState, {prettyPrint: true})).toBe('<p>a</p>\n<p>b</p>');
+    expect(stateToHTML(contentState, {prettyPrint: false})).toBe('<p>a</p><p>b</p>');
+  })
 });

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -227,7 +227,7 @@ class MarkupGenerator {
       nextBlock.getDepth() === block.getDepth() + 1
     ) {
       if (prettyPrint) {
-        this.output.push(`\n`);
+        this.output.push('\n');
       }
       // This is a litle hacky: temporarily stash our current wrapperTag and
       // render child list(s).

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -162,8 +162,11 @@ class MarkupGenerator {
   inlineStyles: StyleMap;
   styleOrder: Array<string>;
 
-  constructor(contentState: ContentState, options: ?Options = {}) {
+  constructor(contentState: ContentState, options: ?Options) {
     this.contentState = contentState;
+    if (options == null) {
+      options = {};
+    }
     this.options = {...DEFAULT_OPTIONS, ...options};
     let [inlineStyles, styleOrder] = combineOrderedStyles(
       options.inlineStyles,

--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -2,6 +2,11 @@
 {"entityMap":{},"blocks":[{"key":"33nh8","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
 <p>a</p>
 
+# two plain-text blocks
+{"entityMap":{},"blocks":[{"key":"b4nv7","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"klgb","text":"b","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}
+<p>a</p>
+<p>b</p>
+
 # Single inline style
 {"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
 <p>asd<strong>f</strong></p>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,7 +15,7 @@ declare module 'draft-js-export-html' {
         inlineStyles?: { [styleName: string]: RenderConfig };
         blockRenderers?: { [blockType: string]: BlockRenderer };
         blockStyleFn?: BlockStyleFn;
-        prettyPrinting? boolean;
+        prettyPrint? boolean;
     }
 
     export function stateToHTML(content: draftjs.ContentState, options?: Options): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,6 +15,7 @@ declare module 'draft-js-export-html' {
         inlineStyles?: { [styleName: string]: RenderConfig };
         blockRenderers?: { [blockType: string]: BlockRenderer };
         blockStyleFn?: BlockStyleFn;
+        prettyPrinting? boolean;
     }
 
     export function stateToHTML(content: draftjs.ContentState, options?: Options): string;


### PR DESCRIPTION
Hello! 👋🏽

Wanted to contribute this change I made to draft-js-export-html for our use at [Drift](https://github.com/Driftt).

My use case is that I needed the output from `stateToHTML` to be all on one line without any indentation. Adding an option here seemed simpler than minifying the HTML output afterward.

This PR introduces a `prettyPrinting` option. This allows the user to specify whether `MarkupGenerator` should include newline characters after closing tags and indentation on new lines.  The option is enabled by default, which is consistent with the current behavior.