### PR TITLE
Fix deprecated getEntity (fixes #67)

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -340,7 +340,7 @@ class MarkupGenerator {
         }
         return content;
       }).join('');
-      let entity = entityKey ? this.contentState.getEntity(entityKey) : null;
+      let entity = entityKey ? getEntity(this.contentState, entityKey) : null;
       // Note: The `toUpperCase` below is for compatability with some libraries that use lower-case for image blocks.
       let entityType = (entity == null) ? null : entity.getType().toUpperCase();
       if (entityType != null && entityType === ENTITY_TYPE.LINK) {
@@ -374,6 +374,10 @@ class MarkupGenerator {
     return newText.join('');
   }
 
+}
+
+function getEntity(contentState, entityKey) {
+  return contentState.getEntity ? contentState.getEntity(entityKey) : Entity.get(entityKey);
 }
 
 function stringifyAttrs(attrs: ?Attributes) {

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -4,6 +4,7 @@ import combineOrderedStyles from './helpers/combineOrderedStyles';
 import normalizeAttributes from './helpers/normalizeAttributes';
 import styleToCSS from './helpers/styleToCSS';
 
+import {Entity} from 'draft-js';
 import {
   getEntityRanges,
   BLOCK_TYPE,

--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -4,7 +4,6 @@ import combineOrderedStyles from './helpers/combineOrderedStyles';
 import normalizeAttributes from './helpers/normalizeAttributes';
 import styleToCSS from './helpers/styleToCSS';
 
-import {Entity} from 'draft-js';
 import {
   getEntityRanges,
   BLOCK_TYPE,
@@ -341,7 +340,7 @@ class MarkupGenerator {
         }
         return content;
       }).join('');
-      let entity = entityKey ? Entity.get(entityKey) : null;
+      let entity = entityKey ? this.contentState.getEntity(entityKey) : null;
       // Note: The `toUpperCase` below is for compatability with some libraries that use lower-case for image blocks.
       let entityType = (entity == null) ? null : entity.getType().toUpperCase();
       if (entityType != null && entityType === ENTITY_TYPE.LINK) {


### PR DESCRIPTION
WARNING: DraftEntity.get will be deprecated soon! Please use "contentState.getEntity" instead.