### PR TITLE
Fix blockRenderers example in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Example:
 ```javascript
 let options = {
   blockRenderers: {
-    ATOMIC: (block) => {
+    atomic: (block) => {
       let data = block.getData();
-      if (data.foo === 'bar') {
+      if (data.get('foo') === 'bar') {
         return '<div>' + escape(block.getText()) + '</div>';
       }
     },


### PR DESCRIPTION
Just a few things I noticed while implementing a custom blockRenderer. Not sure if this applies to the other examples.

* The block type is the string "atomic", not "ATOMIC". If it's supposed to reference a variable, it should perhaps be `[ATOMIC]`?
* `block.getData()` returns a `Map`, so we need `data.get('prop')` to fetch it.