### PR TITLE
No longer filling empty elements with extraneous `<br>` elements

### DIFF
--- a/src/stateToHTML.js
+++ b/src/stateToHTML.js
@@ -313,7 +313,7 @@ class MarkupGenerator {
     let text = block.getText();
     if (text === '') {
       // Prevent element collapse if completely empty.
-      return BREAK;
+      return '';
     }
     text = this.preserveWhitespace(text);
     let charMetaList: CharacterMetaList = block.getCharacterList();


### PR DESCRIPTION
No longer filling empty elements with extraneous `<br>` elements. It doesn't break any tests. The wrapping elements don't self-collapse as the comments would suggest.