### PR TITLE
Added the option not to use the parent tag

### DIFF
--- a/packages/draft-js-export-html/README.md
+++ b/packages/draft-js-export-html/README.md
@@ -67,6 +67,8 @@ let html = stateToHTML(contentState, options);
 
 If you don't want to define the full custom render for a block, you can define the type of the parent block tag that will be created if the block type doesn't match any known type.
 
+If you don't want any parent block tag, you can set `defaultBlockTag` to `null`.
+
 Example:
 
 ```javascript

--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -213,4 +213,32 @@ describe('stateToHTML', () => {
       '<p><a href="/users/mikaelwaltersson" class="mention"><em>a</em></a></p>',
     );
   });
+
+  it('should support custom block tag', () => {
+    let contentState = convertFromRaw(
+      {
+        entityMap: {},
+        blocks: [{
+          key: '33nh8',
+          text: 'a',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRange: [],
+          entityRanges: [],
+        }],
+      },
+    );
+
+    expect(stateToHTML(contentState)).toBe(
+      '<p>a</p>',
+    );
+
+    expect(stateToHTML(contentState, {defaultBlockTag: 'h1'})).toBe(
+      '<h1>a</h1>',
+    );
+
+    expect(stateToHTML(contentState, {defaultBlockTag: null})).toBe(
+      'a',
+    );
+  });
 });

--- a/packages/draft-js-export-html/src/stateToHTML.js
+++ b/packages/draft-js-export-html/src/stateToHTML.js
@@ -42,7 +42,7 @@ type Options = {
   blockRenderers?: BlockRendererMap;
   blockStyleFn?: BlockStyleFn;
   entityStyleFn?: EntityStyleFn;
-  defaultBlockTag?: string;
+  defaultBlockTag?: ?string;
 };
 
 const {BOLD, CODE, ITALIC, STRIKETHROUGH, UNDERLINE} = INLINE_STYLE;
@@ -146,6 +146,9 @@ function getTags(blockType: string, defaultBlockTag): Array<string> {
     case BLOCK_TYPE.ATOMIC:
       return ['figure'];
     default:
+      if (defaultBlockTag === null) {
+        return [];
+      }
       return [defaultBlockTag || 'p'];
   }
 }


### PR DESCRIPTION
If you don't want any parent block tag, you can set `defaultBlockTag` to `null`.
