### PR TITLE
Added inline style function

### DIFF
--- a/packages/draft-js-export-html/README.md
+++ b/packages/draft-js-export-html/README.md
@@ -44,7 +44,7 @@ let html = stateToHTML(contentState, options);
 ```
 ### `inlineStylesFn`
 
-You can define custom function to return css object based on inline styles. Similar to draft.js [customStyleFn](https://draftjs.org/docs/api-reference-editor.html#customstylefn).
+You can define custom function to return rendering options based on inline styles. Similar to draft.js [customStyleFn](https://draftjs.org/docs/api-reference-editor.html#customstylefn).
 
 Example:
 
@@ -56,7 +56,10 @@ let options = {
 
     if (color) {
       return {
-        color: color.replace(key, ''),
+        element: 'span',
+        style: {
+          color: color.replace(key, ''),
+        },
       };
     }
   },

--- a/packages/draft-js-export-html/README.md
+++ b/packages/draft-js-export-html/README.md
@@ -42,6 +42,27 @@ let options = {
 };
 let html = stateToHTML(contentState, options);
 ```
+### `inlineStylesFn`
+
+You can define custom function to return css object based on inline styles. Similar to draft.js [customStyleFn](https://draftjs.org/docs/api-reference-editor.html#customstylefn).
+
+Example:
+
+```javascript
+let options = {
+  inlineStyleFn: (styles) => {
+    let key = 'color-';
+    let color = styles.filter((value) => value.startsWith(key)).first();
+
+    if (color) {
+      return {
+        color: color.replace(key, ''),
+      };
+    }
+  },
+};
+let html = stateToHTML(contentState, options);
+```
 
 ### `blockRenderers`
 

--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -110,6 +110,41 @@ describe('stateToHTML', () => {
     );
   });
 
+  it('should support inline style function', () => {
+    let options = {
+      inlineStyleFn: (styles) => {
+        let key = 'color-';
+        let color = styles.filter((value) => value.startsWith(key)).first();
+
+        if (color) {
+          return {
+            color: color.replace(key, ''),
+          };
+        }
+      },
+    };
+
+    let contentState = convertFromRaw(
+      //<p>Hello <span style="color: #f8b400">world</span></p>
+      {
+        entityMap: {},
+        blocks: [{
+          key: '7h6g0',
+          text: 'Hello world',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRanges: [{offset: 6, length: 5, style: 'color-#f8b400'}],
+          entityRanges: [],
+          data: {},
+        }],
+      },
+    );
+
+    expect(stateToHTML(contentState, options)).toBe(
+      '<p>Hello <span style="color: #f8b400">world</span></p>',
+    );
+  });
+
   it('should support custom block styles', () => {
     let options = {
       blockStyleFn: (block) => {

--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -118,7 +118,10 @@ describe('stateToHTML', () => {
 
         if (color) {
           return {
-            color: color.replace(key, ''),
+            element: 'span',
+            style: {
+              color: color.replace(key, ''),
+            },
           };
         }
       },

--- a/packages/draft-js-export-html/src/stateToHTML.js
+++ b/packages/draft-js-export-html/src/stateToHTML.js
@@ -18,6 +18,7 @@ import type {
   EntityInstance,
 } from 'draft-js';
 import type {CharacterMetaList} from 'draft-js-utils';
+import type {DraftInlineStyle} from 'draft-js/lib/DraftInlineStyle';
 
 type AttrMap = {[key: string]: string};
 type Attributes = {[key: string]: string};
@@ -36,9 +37,11 @@ type StyleMap = {[styleName: string]: RenderConfig};
 
 type BlockStyleFn = (block: ContentBlock) => ?RenderConfig;
 type EntityStyleFn = (entity: Entity) => ?RenderConfig;
+type InlineStyleFn = (style: DraftInlineStyle) => ?Object;
 
 type Options = {
   inlineStyles?: StyleMap;
+  inlineStyleFn?: InlineStyleFn;
   blockRenderers?: BlockRendererMap;
   blockStyleFn?: BlockStyleFn;
   entityStyleFn?: EntityStyleFn;


### PR DESCRIPTION
Sometimes styles need to be generated dynamically based on current draft styles. 
Ex. If you support arbitrary colors it's impossible to specify all of them in `inlineStyles` map.
For such cases, there's [customStyleMap](https://draftjs.org/docs/api-reference-editor.html#customstylemap) in draft.js `Editor` component. 
Suggest adding such functionality here as well - `inlineStylesFn`.
Fixes #82 