### PR TITLE
Fixes Alt Text Markdown

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -222,7 +222,7 @@ class MarkupGenerator {
         } else if (entity != null && entity.getType() === ENTITY_TYPE.IMAGE) {
           let data = entity.getData();
           let src = data.src || '';
-          let alt = data.alt ? ` "${escapeTitle(data.alt)}"` : '';
+          let alt = data.alt ? `${escapeTitle(data.alt)}` : '';
           return `![${alt}](${encodeURL(src)})`;
         } else {
           return content;


### PR DESCRIPTION
Currently any image alt text exported is including a space and quotation marks that shouldn't be there based on markdown syntax.