### PR TITLE
Fixes Alt Text Markdown

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -222,7 +222,7 @@ class MarkupGenerator {
         } else if (entity != null && entity.getType() === ENTITY_TYPE.IMAGE) {
           let data = entity.getData();
           let src = data.src || '';
-          let alt = data.alt ? ` "${escapeTitle(data.alt)}"` : '';
+          let alt = data.alt ? `${escapeTitle(data.alt)}` : '';
           return `![${alt}](${encodeURL(src)})`;
         } else {
           return content;

--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -16,7 +16,7 @@ _Bold_**Italic**
 
 >> Image with alt
 {"entityMap":{"0":{"type":"IMAGE","mutability":"MUTABLE","data":{"src":"/a.jpg","alt":"x"}}},"blocks":[{"key":"f131g","text":"Hello World.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":5,"length":1,"key":0}]}]}
-Hello![ "x"](/a.jpg)World.
+Hello![x](/a.jpg)World.
 
 >> Image with empty alt
 {"entityMap":{"0":{"type":"IMAGE","mutability":"MUTABLE","data":{"src":"/a.jpg","alt":""}}},"blocks":[{"key":"f131g","text":"Hello World.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":5,"length":1,"key":0}]}]}


### PR DESCRIPTION
Fixes issue of markdown syntax having quotations added within it. Markdown syntax has alt text directly within the brackets. Reference: [https://daringfireball.net/projects/markdown/syntax#img](https://daringfireball.net/projects/markdown/syntax#img)