### PR TITLE
[ADD] Ability to link mentions and autolink urls

### DIFF
--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -2,6 +2,14 @@
 {"entityMap":{},"blocks":[{"key":"33nh8","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
 a
 
+>> Autolink
+{"entityMap":{},"blocks":[{"key":"33nh8","text":"https://foo.com","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
+[https://foo.com](https://foo.com)
+
+>> Autolink with other text
+{"entityMap":{},"blocks":[{"key":"33nh8","text":"this is a test https://foo.com links","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
+this is a test [https://foo.com](https://foo.com) links
+
 >> Single Inline Style
 {"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
 asd**f**

--- a/packages/draft-js-utils/src/Constants.js
+++ b/packages/draft-js-utils/src/Constants.js
@@ -20,6 +20,7 @@ export const BLOCK_TYPE = {
 export const ENTITY_TYPE = {
   LINK: 'LINK',
   IMAGE: 'IMAGE',
+  MENTION: 'MENTION',
 };
 
 export const INLINE_STYLE = {


### PR DESCRIPTION
Currently the `stateToMarkdown` will strip the anchor tag created by mentioning using https://github.com/jpuri/react-draft-wysiwyg, this allows the mention to maintain the link.

It also adds support for auto-linking urls a la Github flavored markdown