### PR TITLE
Add support for overriding block element using blockStyleFn

### DIFF
--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -208,7 +208,7 @@ describe('stateToHTML', () => {
 
   it('blockStyleFn should support setting custom element', () => {
     let options = {
-      blockStyleFn: (block) => ({
+      blockStyleFn: () => ({
         element: 'li',
       }),
     };
@@ -237,7 +237,7 @@ describe('stateToHTML', () => {
     expect(stateToHTML(contentState1, options)).toBe(
       '<li>Hello <em>world</em>.</li>',
     );
-  })
+  });
 
   it('should support custom entity styles', () => {
     let options = {

--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -206,6 +206,39 @@ describe('stateToHTML', () => {
     );
   });
 
+  it('blockStyleFn should support setting custom element', () => {
+    let options = {
+      blockStyleFn: (block) => ({
+        element: 'li',
+      }),
+    };
+
+    let contentState1 = convertFromRaw(
+      // <h1>Hello <em>world</em>.</h1>
+      {
+        entityMap: {},
+        blocks: [
+          {
+            key: 'dn025',
+            text: 'Hello world.',
+            type: 'unstyled',
+            depth: 0,
+            inlineStyleRanges: [{offset: 6, length: 5, style: 'ITALIC'}],
+            entityRanges: [],
+          },
+        ],
+      }, // eslint-disable-line
+    );
+
+    expect(stateToHTML(contentState1)).toBe(
+      '<p>Hello <em>world</em>.</p>',
+    );
+
+    expect(stateToHTML(contentState1, options)).toBe(
+      '<li>Hello <em>world</em>.</li>',
+    );
+  })
+
   it('should support custom entity styles', () => {
     let options = {
       entityStyleFn: (entity) => {

--- a/packages/draft-js-export-html/src/stateToHTML.js
+++ b/packages/draft-js-export-html/src/stateToHTML.js
@@ -285,7 +285,7 @@ class MarkupGenerator {
 
     let attrString;
     if (this.options.blockStyleFn) {
-      let {attributes, style} = this.options.blockStyleFn(block) || {};
+      let {attributes, style, element} = this.options.blockStyleFn(block) || {};
       // Normalize `className` -> `class`, etc.
       attributes = normalizeAttributes(attributes);
       if (style != null) {
@@ -294,6 +294,9 @@ class MarkupGenerator {
           attributes == null
             ? {style: styleAttr}
             : {...attributes, style: styleAttr};
+      }
+      if (element != null) {
+        tags = [element];
       }
       attrString = stringifyAttrs(attributes);
     } else {
@@ -307,6 +310,14 @@ class MarkupGenerator {
 
   writeEndTag(block, defaultBlockTag) {
     let tags = getTags(block.getType(), defaultBlockTag);
+
+    if (this.options.blockStyleFn) {
+      let {element} = this.options.blockStyleFn(block) || {};
+      if (element != null) {
+        tags = [element];
+      }
+    }
+
     if (tags.length === 1) {
       this.output.push(`</${tags[0]}>\n`);
     } else {


### PR DESCRIPTION
This pull request adds the possibility to override the rendered block element using `blockStyleFn`. This functionality is currently supported in `inlineStyleFn` so seems fitting that it can be done in `blockStyleFn` as well.

It is currently possible to override the block tag using a custom `blockRenderer`. The problem is that using a `blockRenderer` causes the conversion to skip `renderBlockContent` which does a lot of good stuff. When all you want is to modify the block element but keep the default blockRenderer,  this functionality comes in handy!