### PR TITLE
InlineStyleFn adjustments - produce separated elements for each inline style

### DIFF
--- a/packages/draft-js-export-html/README.md
+++ b/packages/draft-js-export-html/README.md
@@ -42,7 +42,7 @@ let options = {
 };
 let html = stateToHTML(contentState, options);
 ```
-### `inlineStylesFn`
+### `inlineStyleFn`
 
 You can define custom function to return rendering options based on inline styles. Similar to draft.js [customStyleFn](https://draftjs.org/docs/api-reference-editor.html#customstylefn).
 

--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -112,15 +112,14 @@ describe('stateToHTML', () => {
 
   it('should support inline style function', () => {
     let options = {
-      inlineStyleFn: (styles) => {
+      inlineStyleFn: (style) => {
         let key = 'color-';
-        let color = styles.filter((value) => value.startsWith(key)).first();
 
-        if (color) {
+        if (style.startsWith(key)) {
           return {
             element: 'span',
             style: {
-              color: color.replace(key, ''),
+              color: style.replace(key, ''),
             },
           };
         }

--- a/packages/draft-js-export-html/src/stateToHTML.js
+++ b/packages/draft-js-export-html/src/stateToHTML.js
@@ -37,7 +37,7 @@ type StyleMap = {[styleName: string]: RenderConfig};
 
 type BlockStyleFn = (block: ContentBlock) => ?RenderConfig;
 type EntityStyleFn = (entity: Entity) => ?RenderConfig;
-type InlineStyleFn = (style: DraftInlineStyle) => ?RenderConfig;
+type InlineStyleFn = (style: string) => ?RenderConfig;
 
 type Options = {
   inlineStyles?: StyleMap;
@@ -344,18 +344,21 @@ class MarkupGenerator {
       return content;
     }
 
-    const renderConfig = this.inlineStyleFn(styleSet);
-    if (!renderConfig) {
-      return content;
-    }
+    return styleSet.reduce((nextContent, styleItem) => {
+      const renderConfig = this.inlineStyleFn(styleItem);
 
-    const {element = 'span', attributes, style} = renderConfig;
-    const attrString = stringifyAttrs({
-      ...attributes,
-      style: style && styleToCSS(style),
-    });
+      if (!renderConfig) {
+        return nextContent;
+      }
 
-    return `<${element}${attrString}>${content}</${element}>`;
+      const {element = 'span', attributes, style} = renderConfig;
+      const attrString = stringifyAttrs({
+        ...attributes,
+        style: style && styleToCSS(style),
+      });
+
+      return `<${element}${attrString}>${nextContent}</${element}>`;
+    }, content);
   }
 
   renderBlockContent(block: ContentBlock): string {

--- a/packages/draft-js-export-html/src/stateToHTML.js
+++ b/packages/draft-js-export-html/src/stateToHTML.js
@@ -18,7 +18,6 @@ import type {
   EntityInstance,
 } from 'draft-js';
 import type {CharacterMetaList} from 'draft-js-utils';
-import type {DraftInlineStyle} from 'draft-js/lib/DraftInlineStyle';
 
 type AttrMap = {[key: string]: string};
 type Attributes = {[key: string]: string};

--- a/packages/draft-js-export-html/src/stateToHTML.js
+++ b/packages/draft-js-export-html/src/stateToHTML.js
@@ -343,8 +343,10 @@ class MarkupGenerator {
       return content;
     }
 
+    const inlineStyleFn = this.inlineStyleFn;
+
     return styleSet.reduce((nextContent, styleItem) => {
-      const renderConfig = this.inlineStyleFn(styleItem);
+      const renderConfig = inlineStyleFn(styleItem);
 
       if (!renderConfig) {
         return nextContent;


### PR DESCRIPTION
Current implementation of `InlineStyleFn()` accepts whole style set but can produce only one element. It leads to the troubles when you'll want to parse it back using `draft-js-import-html` because it can produce only one inline style per one element.

Ex:
1. We have 2 inline styles: color, font size
2. Generated following tag using `draft-js-export-html`
```html
<span style="color: #000; font-size: 14px" />
```
3. Want to parse it back via `draft-js-import-html`'s `customInlineFn` but it can produce only one style:
```javascript
customInlineFn: (element, { Style }) => {
    if (element.style.color) {
      return Style('color-' + element.style.color); // this one
    } 
    if (element.style.fontSize) {
      return Style('font-size-' + element.style.fontSize); // or this one
    } 
  }
```

The solution (implemented): generate separated element for each inline style (like it's done via `inlineStyles `)
Alternative solution: support returning `Style`'s array from `customInlineFn` import method