### PR TITLE
Add support for multiple custom styles, separated by a space

### DIFF
--- a/packages/draft-js-import-element/src/stateFromElement.js
+++ b/packages/draft-js-import-element/src/stateFromElement.js
@@ -341,7 +341,7 @@ class ContentGenerator {
     if (customInline != null) {
       switch (customInline.type) {
         case 'STYLE': {
-          style = style.add(customInline.style);
+          style = style.union(customInline.style.split(' '));
           break;
         }
         case 'ENTITY': {
@@ -385,8 +385,11 @@ class ContentGenerator {
     let style = block.styleStack.slice(-1)[0];
     let entity = block.entityStack.slice(-1)[0];
     let charMetadata = CharacterMetadata.create({
-      style: style,
       entity: entity,
+    });
+    style.forEach((s) => {
+      charMetadata = CharacterMetadata.applyStyle(charMetadata, s);
+      return true;
     });
     let seq: CharacterMetaSeq = Repeat(charMetadata, text.length);
     block.textFragments.push({


### PR DESCRIPTION
When you do this,

```javascript
stateFromHTML(htmlContent, {
  customInlineFn: (element, { Style, Entity }) => {
    const { color, fontSize } = element.style
    return Style(`color${color} fontSize${fontSize} FOO BAR`)
  },
})
```

now each inline element has overlapping four styles.