### PR TITLE
Document usage

### DIFF
--- a/packages/draft-js-export-markdown/README.md
+++ b/packages/draft-js-export-markdown/README.md
@@ -10,6 +10,13 @@ It was extracted from [React-RTE](https://react-rte.org) and placed into a separ
 
 This project is still under development. If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).
 
+## How to Use
+
+    import { stateToMarkdown } from "draft-js-export-markdown";
+    const markdown = stateToMarkdown(
+      this.state.editorState.getCurrentContent()
+    )
+
 ## License
 
 This software is [ISC Licensed](/LICENSE).


### PR DESCRIPTION
Thanks a lot for sharing `draft-js-utils` 🙂 

The API for the markdown exporter is pretty intuitive when you've seen the `stateToHTML` example, but it still took me some time to figure out. So I thought that it might be nice to add some simple usage documentation.