### PR TITLE
Allow multiple inlineStyles to be returned by customInlineFn

### DIFF
--- a/packages/draft-js-import-element/src/__tests__/stateFromElement-test.js
+++ b/packages/draft-js-import-element/src/__tests__/stateFromElement-test.js
@@ -146,7 +146,7 @@ describe('stateFromElement', () => {
     });
   });
 
-  it.only('should return multiple style from customInlineFn', () => {
+  it('should return multiple style from customInlineFn', () => {
     let element = new ElementNode('div', [], [
       new ElementNode(
         'span',

--- a/packages/draft-js-import-element/src/__tests__/stateFromElement-test.js
+++ b/packages/draft-js-import-element/src/__tests__/stateFromElement-test.js
@@ -146,6 +146,41 @@ describe('stateFromElement', () => {
     });
   });
 
+  it.only('should return multiple style from customInlineFn', () => {
+    let element = new ElementNode('div', [], [
+      new ElementNode(
+        'span',
+        [{style: 'font-family', value: 'sans-serif'},{style: 'font-size', value: '12px'},],
+        [new TextNode('Hello')]
+      )
+    ]);
+    let options = {
+      customInlineFn(el, {Style}) {
+        if (el.tagName === 'SPAN') {
+          return Style(['CUSTOM_STYLE_1', 'CUSTOM_STYLE_2']);
+        }
+      },
+    };
+    let contentState = stateFromElement(element, options);
+    let rawContentState = removeBlockKeys(convertToRaw(contentState));
+    expect(rawContentState).toEqual({
+      entityMap: {},
+      blocks: [
+        {
+          text: 'Hello',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRanges: [
+            {offset: 0, length: 5, style: 'CUSTOM_STYLE_1'},
+            {offset: 0, length: 5, style: 'CUSTOM_STYLE_2'}
+          ],
+          entityRanges: [],
+          data: {},
+        },
+      ],
+    });
+  });
+
   it('should support option elementStyles', () => {
     let textNode = new TextNode('Superscript');
     let element = new ElementNode('sup', [], [textNode]);

--- a/packages/draft-js-import-element/src/stateFromElement.js
+++ b/packages/draft-js-import-element/src/stateFromElement.js
@@ -341,7 +341,7 @@ class ContentGenerator {
     if (customInline != null) {
       switch (customInline.type) {
         case 'STYLE': {
-          style = style.add(customInline.style);
+          [].concat(customInline.style).forEach(customStyle => style = style.add(customStyle));
           break;
         }
         case 'ENTITY': {


### PR DESCRIPTION
## What does this PR do?
Previously the customStyleFn only allowed you to apply a single style. This PR improves the behavior of the customInlineStyleFn by allowing it to return multiple inlineStyles so they can be applied to an an element.

## Does it break anything?
This addition would enhance the functionality of the customStyleFn in a backwards compatible way. 

## Does it have tests?
Yes!

## Who would benefit from this?

Here are several issues open that this functionality fixes.

1. https://github.com/sstur/draft-js-utils/issues/142
2. https://github.com/sstur/draft-js-utils/issues/154
3. https://github.com/webdeveloperpr/draft-js-custom-styles/issues/2
4. https://github.com/sstur/draft-js-utils/pull/136

I would love to have this merged. Please let me know your thoughts.