### PR TITLE
[import-markdown] Support Parser Options (marked)

### DIFF
--- a/packages/draft-js-import-markdown/src/MarkdownParser.js
+++ b/packages/draft-js-import-markdown/src/MarkdownParser.js
@@ -109,7 +109,7 @@ block.gfm.paragraph = replace(block.paragraph)(
 function Lexer(options) {
   this.tokens = [];
   this.tokens.links = {};
-  this.options = assign({}, options || defaults);
+  this.options = options ? assign({}, defaults, options) : assign({}, defaults);
   this.rules = block.normal;
 
   if (this.options.gfm) {

--- a/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
+++ b/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
@@ -5,8 +5,8 @@ import stateFromMarkdown from '../stateFromMarkdown';
 import {convertToRaw} from 'draft-js';
 
 describe('stateFromMarkdown', () => {
-  let markdown = 'Hello World';
   it('should create content state', () => {
+    let markdown = 'Hello World';
     let contentState = stateFromMarkdown(markdown);
     let rawContentState = convertToRaw(contentState);
     let blocks = removeKeys(rawContentState.blocks);
@@ -21,9 +21,9 @@ describe('stateFromMarkdown', () => {
       },
     ]);
   });
-  it('should correctly move code blocks', () => {
-    let codeMarkdown = "```\nconst a = 'b'\n```";
-    let contentState = stateFromMarkdown(codeMarkdown);
+  it('should correctly handle code blocks', () => {
+    let markdown = "```\nconst a = 'b'\n```";
+    let contentState = stateFromMarkdown(markdown);
     let rawContentState = convertToRaw(contentState);
     let blocks = removeKeys(rawContentState.blocks);
     expect(blocks).toEqual([
@@ -43,10 +43,26 @@ describe('stateFromMarkdown', () => {
       },
     ]);
   });
-  it('should correctly move images with complex srcs', () => {
+  it('should correctly handle linebreaks option', () => {
+    let markdown = 'Hello\nWorld';
+    let contentState = stateFromMarkdown(markdown, {parserOptions: {breaks: true}});
+    let rawContentState = convertToRaw(contentState);
+    let blocks = removeKeys(rawContentState.blocks);
+    expect(blocks).toEqual([
+      {
+        text: 'Hello\nWorld',
+        type: 'unstyled',
+        depth: 0,
+        inlineStyleRanges: [],
+        entityRanges: [],
+        data: {},
+      },
+    ]);
+  });
+  it('should correctly handle images with complex srcs', () => {
     const src = 'https://spectrum.imgix.net/threads/c678032e-68a4-4e14-956d-abfa444a707d/Captura%20de%20pantalla%202017-08-19%20a%20la(s)%2000.14.09.png.0.29802431313299893';
-    let input = `![](${src})`;
-    let contentState = stateFromMarkdown(input);
+    let markdown = `![](${src})`;
+    let contentState = stateFromMarkdown(markdown);
     let rawContentState = convertToRaw(contentState);
     let blocks = removeKeys(rawContentState.blocks);
     expect({

--- a/packages/draft-js-import-markdown/src/stateFromMarkdown.js
+++ b/packages/draft-js-import-markdown/src/stateFromMarkdown.js
@@ -11,12 +11,16 @@ type Options = {
   blockTypes?: {[key: string]: string};
   customBlockFn?: CustomBlockFn;
   customInlineFn?: CustomInlineFn;
+  parserOptions?: {[key: string]: mixed}; // TODO: Be more explicit
 };
+
+let defaultOptions: Options = {};
 
 export default function stateFromMarkdown(
   markdown: string,
   options?: Options,
 ): ContentState {
-  let element = MarkdownParser.parse(markdown, {getAST: true});
-  return stateFromElement(element, options);
+  let {parserOptions, ...otherOptions} = options || defaultOptions;
+  let element = MarkdownParser.parse(markdown, {getAST: true, ...parserOptions});
+  return stateFromElement(element, otherOptions);
 }


### PR DESCRIPTION
Correctly pass down parserOptions to [our fork of] the [marked](https://marked.js.org) parser.

This should help fix https://github.com/withspectrum/spectrum/pull/4472

/cc @mxstbr 