### PR TITLE
Fix code escaping

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -207,7 +207,18 @@ class MarkupGenerator {
             if (!text) {
               return '';
             }
-            let content = encodeContent(text);
+            let content = text;
+            // Don't encode any text inside a code block.
+            if (blockType === BLOCK_TYPE.CODE) {
+              return content;
+            }
+            // NOTE: We attempt some basic character escaping here, although
+            // I don't know if escape sequences are really valid in markdown,
+            // there's not a canonical spec to lean on.
+            if (style.has(CODE)) {
+              return '`' + encodeCode(content) + '`';
+            }
+            content = encodeContent(text);
             if (style.has(BOLD)) {
               content = `**${content}**`;
             }
@@ -221,10 +232,6 @@ class MarkupGenerator {
             if (style.has(STRIKETHROUGH)) {
               // TODO: encode `~`?
               content = `~~${content}~~`;
-            }
-            if (style.has(CODE)) {
-              content =
-                blockType === BLOCK_TYPE.CODE ? content : '`' + content + '`';
             }
             return content;
           })
@@ -260,6 +267,10 @@ function canHaveDepth(blockType: any): boolean {
 
 function encodeContent(text) {
   return text.replace(/[*_`]/g, '\\$&');
+}
+
+function encodeCode(text) {
+  return text.replace(/`/g, '\\`');
 }
 
 // Encode chars that would normally be allowed in a URL but would conflict with

--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -62,3 +62,13 @@ let x = 1;
 ```
 
 Great!
+
+>> Underscores in inline code
+{"entityMap":{},"blocks":[{"text":"hello_world","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":11,"style":"CODE"}],"entityRanges":[],"data":{}}]}
+`hello_world`
+
+>> Special characters in code block | {"gfm": true}
+{"entityMap":{},"blocks":[{"text":"callback(num_items * 1 + 2, ~foo, `string`);","type":"code-block","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}
+```
+callback(num_items * 1 + 2, ~foo, `string`);
+```


### PR DESCRIPTION
We should not escape underscores in inline code, and we should not escape any characters in code blocks.

Actually I'm not sure what characters we **_should_** escape in different contexts, but if anyone knows a reference for this, even for github flavored markdown, I'd be keen to know.
