### PR TITLE
Use <figure>s for images inserted from markdown

### DIFF
--- a/packages/draft-js-import-markdown/src/MarkdownParser.js
+++ b/packages/draft-js-import-markdown/src/MarkdownParser.js
@@ -666,7 +666,11 @@ Renderer.prototype.image = function(href, title, alt) {
   if (alt) {
     attributes.push({name: 'alt', value: alt});
   }
-  return new ElementNode('img', attributes, SELF_CLOSING);
+  return new ElementNode(
+    'figure',
+    [],
+    [new ElementNode('img', attributes, SELF_CLOSING)],
+  );
 };
 
 Renderer.prototype.text = function(childNode) {

--- a/packages/draft-js-import-markdown/src/MarkdownParser.js
+++ b/packages/draft-js-import-markdown/src/MarkdownParser.js
@@ -37,6 +37,7 @@ var defaults = {
   langPrefix: 'lang-',
   renderer: new Renderer(),
   xhtml: false,
+  atomicImages: false,
 };
 
 /**
@@ -666,11 +667,13 @@ Renderer.prototype.image = function(href, title, alt) {
   if (alt) {
     attributes.push({name: 'alt', value: alt});
   }
-  return new ElementNode(
-    'figure',
-    [],
-    [new ElementNode('img', attributes, SELF_CLOSING)],
-  );
+  let img = new ElementNode('img', attributes, SELF_CLOSING);
+  // Wrap the image in a <figure> if we want "atomic" images.
+  if (this.options.atomicImages) {
+    return new ElementNode('figure', [], [img]);
+  } else {
+    return img;
+  }
 };
 
 Renderer.prototype.text = function(childNode) {

--- a/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
+++ b/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
@@ -196,7 +196,7 @@ describe('stateFromMarkdown', () => {
 });
 
 function removeKeys(blocks) {
-  return blocks.map(block => {
+  return blocks.map((block) => {
     // eslint-disable-next-line no-unused-vars
     let {key, ...other} = block;
     return other;

--- a/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
+++ b/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
@@ -61,62 +61,6 @@ describe('stateFromMarkdown', () => {
       },
     ]);
   });
-  it('should correctly handle images in the middle of text', () => {
-    const src = 'https://google.com/logo.png';
-    let markdown = `Hey look at this: ![](${src}) Pretty cool!`;
-    let contentState = stateFromMarkdown(markdown);
-    let rawContentState = convertToRaw(contentState);
-    let blocks = removeKeys(rawContentState.blocks);
-    expect({
-      ...rawContentState,
-      blocks,
-    }).toEqual({
-      entityMap: {
-        // This is necessary due to flow not supporting non-string literal property keys
-        // eslint-disable-next-line quote-props
-        '0': {
-          type: 'IMAGE',
-          mutability: 'MUTABLE',
-          data: {
-            src: src,
-            alt: alt,
-          },
-        },
-      },
-      blocks: [
-        {
-          text: 'Hey look at this: ',
-          type: 'unstyled',
-          depth: 0,
-          inlineStyleRanges: [],
-          entityRanges: [],
-          data: {},
-        },
-        {
-          text: ' ',
-          type: 'atomic',
-          depth: 0,
-          inlineStyleRanges: [],
-          entityRanges: [
-            {
-              offset: 0,
-              length: 1,
-              key: 0,
-            },
-          ],
-          data: {},
-        },
-        {
-          text: 'Pretty cool!',
-          type: 'unstyled',
-          depth: 0,
-          inlineStyleRanges: [],
-          entityRanges: [],
-          data: {},
-        },
-      ],
-    });
-  });
   it('should correctly handle images with alt text', () => {
     const src = 'https://google.com/logo.png';
     const alt = 'The Google Logo';

--- a/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
+++ b/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
@@ -65,7 +65,9 @@ describe('stateFromMarkdown', () => {
     const src = 'https://google.com/logo.png';
     const alt = 'The Google Logo';
     let markdown = `![${alt}](${src})`;
-    let contentState = stateFromMarkdown(markdown);
+    let contentState = stateFromMarkdown(markdown, {
+      parserOptions: {atomicImages: true},
+    });
     let rawContentState = convertToRaw(contentState);
     let blocks = removeKeys(rawContentState.blocks);
     expect({
@@ -73,9 +75,7 @@ describe('stateFromMarkdown', () => {
       blocks,
     }).toEqual({
       entityMap: {
-        // This is necessary due to flow not supporting non-string literal property keys
-        // eslint-disable-next-line quote-props
-        '0': {
+        [0]: {
           type: 'IMAGE',
           mutability: 'MUTABLE',
           data: {
@@ -114,9 +114,7 @@ describe('stateFromMarkdown', () => {
       blocks,
     }).toEqual({
       entityMap: {
-        // This is necessary due to flow not supporting non-string literal property keys
-        // eslint-disable-next-line quote-props
-        '0': {
+        [0]: {
           type: 'IMAGE',
           mutability: 'MUTABLE',
           data: {
@@ -127,7 +125,7 @@ describe('stateFromMarkdown', () => {
       blocks: [
         {
           text: ' ',
-          type: 'atomic',
+          type: 'unstyled',
           depth: 0,
           inlineStyleRanges: [],
           entityRanges: [
@@ -152,17 +150,14 @@ describe('stateFromMarkdown', () => {
       blocks,
     }).toEqual({
       entityMap: {
-        // This is necessary due to flow not supporting non-string literal property keys
-        // eslint-disable-next-line quote-props
-        '0': {
+        [0]: {
           type: 'LINK',
           mutability: 'MUTABLE',
           data: {
             url: 'https://google.com',
           },
         },
-        // eslint-disable-next-line quote-props
-        '1': {
+        [1]: {
           type: 'LINK',
           mutability: 'MUTABLE',
           data: {

--- a/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
+++ b/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
@@ -61,6 +61,103 @@ describe('stateFromMarkdown', () => {
       },
     ]);
   });
+  it('should correctly handle images in the middle of text', () => {
+    const src = 'https://google.com/logo.png';
+    let markdown = `Hey look at this: ![](${src}) Pretty cool!`;
+    let contentState = stateFromMarkdown(markdown);
+    let rawContentState = convertToRaw(contentState);
+    let blocks = removeKeys(rawContentState.blocks);
+    expect({
+      ...rawContentState,
+      blocks,
+    }).toEqual({
+      entityMap: {
+        // This is necessary due to flow not supporting non-string literal property keys
+        // eslint-disable-next-line quote-props
+        '0': {
+          type: 'IMAGE',
+          mutability: 'MUTABLE',
+          data: {
+            src: src,
+            alt: alt,
+          },
+        },
+      },
+      blocks: [
+        {
+          text: 'Hey look at this: ',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [],
+          data: {},
+        },
+        {
+          text: ' ',
+          type: 'atomic',
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [
+            {
+              offset: 0,
+              length: 1,
+              key: 0,
+            },
+          ],
+          data: {},
+        },
+        {
+          text: 'Pretty cool!',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [],
+          data: {},
+        },
+      ],
+    });
+  });
+  it('should correctly handle images with alt text', () => {
+    const src = 'https://google.com/logo.png';
+    const alt = 'The Google Logo';
+    let markdown = `![${alt}](${src})`;
+    let contentState = stateFromMarkdown(markdown);
+    let rawContentState = convertToRaw(contentState);
+    let blocks = removeKeys(rawContentState.blocks);
+    expect({
+      ...rawContentState,
+      blocks,
+    }).toEqual({
+      entityMap: {
+        // This is necessary due to flow not supporting non-string literal property keys
+        // eslint-disable-next-line quote-props
+        '0': {
+          type: 'IMAGE',
+          mutability: 'MUTABLE',
+          data: {
+            src: src,
+            alt: alt,
+          },
+        },
+      },
+      blocks: [
+        {
+          text: ' ',
+          type: 'atomic',
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [
+            {
+              offset: 0,
+              length: 1,
+              key: 0,
+            },
+          ],
+          data: {},
+        },
+      ],
+    });
+  });
   it('should correctly handle images with complex srcs', () => {
     const src =
       'https://spectrum.imgix.net/threads/c678032e-68a4-4e14-956d-abfa444a707d/Captura%20de%20pantalla%202017-08-19%20a%20la(s)%2000.14.09.png.0.29802431313299893';
@@ -86,7 +183,7 @@ describe('stateFromMarkdown', () => {
       blocks: [
         {
           text: ' ',
-          type: 'unstyled',
+          type: 'atomic',
           depth: 0,
           inlineStyleRanges: [],
           entityRanges: [
@@ -155,7 +252,7 @@ describe('stateFromMarkdown', () => {
 });
 
 function removeKeys(blocks) {
-  return blocks.map((block) => {
+  return blocks.map(block => {
     // eslint-disable-next-line no-unused-vars
     let {key, ...other} = block;
     return other;


### PR DESCRIPTION
This means they will be inserted as `atomic` blocks by `import-element`, making them work out of the box with the `draft-js-image-plugin` :tada:

Closes #147