### PR TITLE
Adjust prettier config to match eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "prettier": {
     "bracketSpacing": false,
     "singleQuote": true,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "arrowParens": "always"
   }
 }


### PR DESCRIPTION
Eslint wants single parens around arrow functions, but prettier was
removing them, leading to annoying lint errors.

This fixes it by adjusting the prettier config to match the eslint config.

An even better fix would be to use `eslint-config-prettier`,
which disables all lint rules related to style, as checking the style
with eslint is unnecessary when using prettier.

That being said, this should be good enough for now.