### PR TITLE
updated url->href key typo

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -241,7 +241,7 @@ class MarkupGenerator {
         let entity = entityKey ? contentState.getEntity(entityKey) : null;
         if (entity != null && entity.getType() === ENTITY_TYPE.LINK) {
           let data = entity.getData();
-          let url = data.url || '';
+          let url = data.href || '';
           let title = data.title ? ` "${escapeTitle(data.title)}"` : '';
           return `[${content}](${encodeURL(url)}${title})`;
         } else if (entity != null && entity.getType() === ENTITY_TYPE.IMAGE) {

--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -241,7 +241,7 @@ class MarkupGenerator {
         let entity = entityKey ? contentState.getEntity(entityKey) : null;
         if (entity != null && entity.getType() === ENTITY_TYPE.LINK) {
           let data = entity.getData();
-          let url = data.href || '';
+          let url = data.href || data.url || '';
           let title = data.title ? ` "${escapeTitle(data.title)}"` : '';
           return `[${content}](${encodeURL(url)}${title})`;
         } else if (entity != null && entity.getType() === ENTITY_TYPE.IMAGE) {


### PR DESCRIPTION
The key for URL in contentState is `href` instead of `url`. This typo was causing an empty URL while converting ContentState to markdown.
A similar issue was fixed for stateToHtml #50 