### PR TITLE
Add language to code block if available

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -131,7 +131,11 @@ class MarkupGenerator {
       case BLOCK_TYPE.CODE: {
         this.insertLineBreaks(1);
         if (this.options.gfm) {
-          this.output.push('```\n');
+          const language =
+            block.getData() && block.getData().get('language')
+              ? block.getData().get('language')
+              : '';
+          this.output.push(`\`\`\`${language}\n`);
           this.output.push(this.renderBlockContent(block) + '\n');
           this.output.push('```\n');
         } else {

--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -72,3 +72,9 @@ Great!
 ```
 callback(num_items * 1 + 2, ~foo, `string`);
 ```
+
+>> code block with language | {"gfm": true}
+{"entityMap":{},"blocks":[{"text":"const js = true","type":"code-block","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"language":"javascript"}}]}
+```javascript
+const js = true
+```


### PR DESCRIPTION
When using `stateToMarkdown` it would previously not add the language of a code block to the markdown even though it was stored in the data attribute. This checks for an available data attribute and adds it.

Ref https://github.com/withspectrum/spectrum/pull/4759#issuecomment-469182018