### PR TITLE
Update ELEM_ATTR_MAP image tag

### DIFF
--- a/packages/draft-js-import-element/src/stateFromElement.js
+++ b/packages/draft-js-import-element/src/stateFromElement.js
@@ -109,7 +109,7 @@ const DATA_ATTRIBUTE = /^data-([a-z0-9-]+)$/;
 // Map element attributes to entity data.
 const ELEM_ATTR_MAP = {
   a: {href: 'url', rel: 'rel', target: 'target', title: 'title'},
-  img: {src: 'src', alt: 'alt'},
+  img: {src: 'src', alt: 'alt', width: 'width', height: 'height'},
 };
 
 const getEntityData = (tagName: string, element: DOMElement) => {


### PR DESCRIPTION
Img tags with "width" defined is missing the attribute when imported.

https://github.com/sstur/draft-js-utils/issues/133