### PR TITLE
draft-js-export-markdown Escaping all markdown characters

### DIFF
--- a/packages/draft-js-export-markdown/package.json
+++ b/packages/draft-js-export-markdown/package.json
@@ -9,7 +9,8 @@
     "watch": "babel src --watch --out-dir lib --ignore \"_*\""
   },
   "dependencies": {
-    "draft-js-utils": "^1.3.3"
+    "draft-js-utils": "^1.3.3",
+    "markdown-escapes": "1.0.3"
   },
   "peerDependencies": {
     "draft-js": ">=0.10.0",

--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -6,6 +6,7 @@ import {
   ENTITY_TYPE,
   INLINE_STYLE,
 } from 'draft-js-utils';
+import markdownEscapes from 'markdown-escapes';
 
 import type {ContentState, ContentBlock} from 'draft-js';
 
@@ -194,6 +195,13 @@ class MarkupGenerator {
     }
   }
 
+  encodeContent(text) {
+    const markdownCharacters = markdownEscapes({gfm: this.options.gfm});
+
+    const regex = new RegExp(`[${'\\' + markdownCharacters.join('\\')}]`, 'g');
+    return text.replace(regex, '\\$&');
+  }
+
   renderBlockContent(block: ContentBlock): string {
     let {contentState} = this;
     let blockType = block.getType();
@@ -224,19 +232,19 @@ class MarkupGenerator {
             if (style.has(CODE)) {
               return '`' + encodeCode(content) + '`';
             }
-            content = encodeContent(text);
+
+            content = this.encodeContent(text);
+
             if (style.has(BOLD)) {
               content = `**${content}**`;
             }
             if (style.has(UNDERLINE)) {
-              // TODO: encode `+`?
               content = `++${content}++`;
             }
             if (style.has(ITALIC)) {
               content = `_${content}_`;
             }
             if (style.has(STRIKETHROUGH)) {
-              // TODO: encode `~`?
               content = `~~${content}~~`;
             }
             return content;
@@ -271,10 +279,6 @@ function canHaveDepth(blockType: any): boolean {
     default:
       return false;
   }
-}
-
-function encodeContent(text) {
-  return text.replace(/[*_`]/g, '\\$&');
 }
 
 function encodeCode(text) {


### PR DESCRIPTION
This escapes all markdown related characters that are listed in [markdown-escapes](https://www.npmjs.com/package/markdown-escapes) npm package.

It should solve issue #175 

Before updating / adding tests, I thought it would be best to discuss this, because it probably needs some changes.

In my opinion the encoding should be enabled by default (With maybe an option to opt out). My reasoning is that for example, if you write character "#" without escaping it would be considered a header in markdown.