### PR TITLE
Escape both parentheses in links

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -283,8 +283,9 @@ function encodeCode(text) {
 
 // Encode chars that would normally be allowed in a URL but would conflict with
 // our markdown syntax: `[foo](http://foo/)`
+const LINK_CHARACTER_REPLACEMENTS = {'(': '%28', ')': '%29'};
 function encodeURL(url) {
-  return url.replace(/\)/g, '%29');
+  return url.replace(/[()]/g, (char) => LINK_CHARACTER_REPLACEMENTS[char]);
 }
 
 // Escape quotes using backslash.

--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -38,6 +38,10 @@ Hello [World](/a).
 {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"/a","title":"f\"oo"}}},"blocks":[{"key":"2m141","text":"Hello World.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":6,"length":5,"key":0}]}]}
 Hello [World](/a "f\"oo").
 
+>> Link with brackets
+{"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx","foo":"x"}}},"blocks":[{"key":"f131g","text":"Hello World.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":6,"length":5,"key":0}]}]}
+Hello [World](http://msdn.microsoft.com/en-us/library/aa752574%28VS.85%29.aspx).
+
 >> Ordered List
 {"entityMap":{},"blocks":[{"key":"33nh8","text":"An ordered list:","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"8kinl","text":"One","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]},{"key":"ekll4","text":"Two","type":"ordered-list-item","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
 An ordered list:

--- a/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
+++ b/packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
@@ -212,6 +212,43 @@ describe('stateFromMarkdown', () => {
       ],
     });
   });
+  it('should correctly parse link containing escaped parenthesis', () => {
+    let markdown = `[link1](http://msdn.microsoft.com/en-us/library/aa752574%28VS.85%29.aspx)`;
+    let contentState = stateFromMarkdown(markdown);
+    let rawContentState = convertToRaw(contentState);
+    let blocks = removeKeys(rawContentState.blocks);
+    expect({
+      ...rawContentState,
+      blocks,
+    }).toEqual({
+      entityMap: {
+        [0]: {
+          type: 'LINK',
+          mutability: 'MUTABLE',
+          data: {
+            url:
+              'http://msdn.microsoft.com/en-us/library/aa752574%28VS.85%29.aspx',
+          },
+        },
+      },
+      blocks: [
+        {
+          text: 'link1',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: [
+            {
+              offset: 0,
+              length: 5,
+              key: 0,
+            },
+          ],
+          data: {},
+        },
+      ],
+    });
+  });
 });
 
 function removeKeys(blocks) {


### PR DESCRIPTION
Prior to this, `draft-js-import-markdown` could not import a link that was output by `draft-js-export-markdown` that contained an open parenthesis `(`.

Failure looked like this:

```
 FAIL  packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js
  ● stateFromMarkdown › should correctly parse link containing escaped parenthesis

    Expected { entityMap: {}, blocks: [ { text: '[link1](http://msdn.microsoft.com/en-us/library/aa752574(VS.85%29.aspx)', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: [], data: {} } ] } to equal { entityMap: { 0: { type: 'LINK', mutability: 'MUTABLE', data: { url: 'http://msdn.microsoft.com/en-us/library/aa752574(VS.85%29.aspx' } } }, blocks: [ { text: 'link1', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: [ { offset: 0, length: 5, key: 0 } ], data: {} } ] }
      
      at assert (node_modules/expect/lib/assert.js:29:9)
      at Expectation.toEqual (node_modules/expect/lib/Expectation.js:81:30)
      at Object.<anonymous> (packages/draft-js-import-markdown/src/__tests__/stateFromMarkdown-test.js:223:5)
          at new Promise (<anonymous>)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

This PR escapes both `(` and `)` in links, enabling greater compatibility between import and export.