### PR TITLE
Add esm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _*
 !__tests__
 /packages/*/lib
+/packages/*/esm
 /node_modules
 /packages/*/node_modules
 *.log

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,9 @@
 module.exports = {
   presets: ['@babel/env', '@babel/react', '@babel/flow'],
   plugins: ['@babel/proposal-class-properties'],
+  env: {
+    esm: {
+      presets: [['@babel/env', {modules: false}]],
+    },
+  },
 };

--- a/packages/draft-js-export-html/.npmignore
+++ b/packages/draft-js-export-html/.npmignore
@@ -1,4 +1,0 @@
-_*
-flow-typed
-src
-test

--- a/packages/draft-js-export-html/package.json
+++ b/packages/draft-js-export-html/package.json
@@ -3,11 +3,17 @@
   "version": "1.3.3",
   "description": "DraftJS: Export ContentState to HTML",
   "main": "lib/main.js",
+  "module": "esm/main.js",
   "typings": "typings/index.d.ts",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "dependencies": {
     "draft-js-utils": "^1.3.3"

--- a/packages/draft-js-export-markdown/.npmignore
+++ b/packages/draft-js-export-markdown/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.eslintignore
-.eslintrc
-.flowconfig
-.travis.yml
-_*
-flow-typed
-src
-test

--- a/packages/draft-js-export-markdown/package.json
+++ b/packages/draft-js-export-markdown/package.json
@@ -3,10 +3,16 @@
   "version": "1.3.3",
   "description": "DraftJS: Export ContentState to Markdown",
   "main": "lib/main.js",
+  "module": "esm/main.js",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "dependencies": {
     "draft-js-utils": "^1.3.3"

--- a/packages/draft-js-import-element/.npmignore
+++ b/packages/draft-js-import-element/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.eslintignore
-.eslintrc
-.flowconfig
-.travis.yml
-_*
-flow-typed
-src
-test

--- a/packages/draft-js-import-element/package.json
+++ b/packages/draft-js-import-element/package.json
@@ -3,10 +3,16 @@
   "version": "1.3.3",
   "description": "DraftJS: Import Element to ContentState",
   "main": "lib/main.js",
+  "module": "esm/main.js",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "dependencies": {
     "draft-js-utils": "^1.3.3",

--- a/packages/draft-js-import-html/.npmignore
+++ b/packages/draft-js-import-html/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.eslintignore
-.eslintrc
-.flowconfig
-.travis.yml
-_*
-flow-typed
-src
-test

--- a/packages/draft-js-import-html/package.json
+++ b/packages/draft-js-import-html/package.json
@@ -3,11 +3,17 @@
   "version": "1.3.3",
   "description": "DraftJS: Import HTML to ContentState",
   "main": "lib/main.js",
+  "module": "esm/main.js",
   "typings": "typings/index.d.ts",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "dependencies": {
     "draft-js-import-element": "^1.3.3"

--- a/packages/draft-js-import-markdown/.npmignore
+++ b/packages/draft-js-import-markdown/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.eslintignore
-.eslintrc
-.flowconfig
-.travis.yml
-_*
-flow-typed
-src
-test

--- a/packages/draft-js-import-markdown/package.json
+++ b/packages/draft-js-import-markdown/package.json
@@ -3,10 +3,16 @@
   "version": "1.3.3",
   "description": "DraftJS: Import Markdown to ContentState",
   "main": "lib/main.js",
+  "module": "esm/main.js",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "dependencies": {
     "draft-js-import-element": "^1.3.3",

--- a/packages/draft-js-utils/.npmignore
+++ b/packages/draft-js-utils/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.eslintignore
-.eslintrc
-.flowconfig
-.travis.yml
-_*
-flow-typed
-src
-test

--- a/packages/draft-js-utils/package.json
+++ b/packages/draft-js-utils/package.json
@@ -3,10 +3,16 @@
   "version": "1.3.3",
   "description": "Collection of utilities for DraftJS",
   "main": "lib/main.js",
+  "module": "esm/main.js",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "peerDependencies": {
     "draft-js": ">=0.10.0",

--- a/packages/synthetic-dom/.npmignore
+++ b/packages/synthetic-dom/.npmignore
@@ -1,7 +1,0 @@
-.babelrc
-.eslintignore
-.eslintrc
-.flowconfig
-_*
-src
-test

--- a/packages/synthetic-dom/package.json
+++ b/packages/synthetic-dom/package.json
@@ -3,10 +3,16 @@
   "version": "1.3.3",
   "description": "Synthetic HTML DOM for use with parsing within React-RTE",
   "main": "lib/main.js",
+  "module": "esm/main.js",
+  "files": [
+    "lib",
+    "esm"
+  ],
   "scripts": {
     "release": "npm run build && npm publish",
-    "build": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
-    "watch": "babel src --root-mode upward --watch --out-dir lib --ignore \"_*\""
+    "build:cjs": "babel src --root-mode upward --out-dir lib --ignore \"_*\"",
+    "build:esm": "NODE_ENV=esm babel src --root-mode upward --out-dir esm --ignore \"_*\"",
+    "build": "yarn build:cjs && yarn build:esm"
   },
   "keywords": [
     "synthetic-dom",


### PR DESCRIPTION
This is useful for bundlers like rollup which does not support commonjs
our of the box. It's also allows webpack to not wrap each module with
commonjs runtime and enable scope hoisting.

AST plugins already support it
https://github.com/icelab/draft-js-ast-importer/blob/master/package.json#L6
https://github.com/icelab/draft-js-ast-exporter/blob/master/package.json#L6

/cc @sibelius 