### PR TITLE
Add null return types to `BlockRenderer` and `defaultBlockTag`

### DIFF
--- a/packages/draft-js-export-html/typings/index.d.ts
+++ b/packages/draft-js-export-html/typings/index.d.ts
@@ -13,7 +13,7 @@ declare module 'draft-js-export-html' {
     };
 
     export interface Options {
-        defaultBlockTag?: string;
+        defaultBlockTag?: string|null;
         inlineStyles?: { [styleName: string]: RenderConfig };
         blockRenderers?: { [blockType: string]: BlockRenderer };
         blockStyleFn?: BlockStyleFn;

--- a/packages/draft-js-export-html/typings/index.d.ts
+++ b/packages/draft-js-export-html/typings/index.d.ts
@@ -5,7 +5,7 @@ declare module 'draft-js-export-html' {
 
     type BlockStyleFn = (block: draftjs.ContentBlock) => RenderConfig|undefined;
     type EntityStyleFn = (entity: draftjs.EntityInstance) => RenderConfig|undefined;
-    type BlockRenderer = (block: draftjs.ContentBlock) => string;
+    type BlockRenderer = (block: draftjs.ContentBlock) => string|null|undefined;
     type RenderConfig = {
         element?: string;
         attributes?: any;


### PR DESCRIPTION
## Description
This PR adds two `null` types to the TypeScript definition of `draft-js-export-html`: `BlockRenderer` and `defaultBlockTag`.
These `null` return types are present in the documentation (and code), but were missing from the TypeScript definition, thus causing type linting/compilation errors.
I decided to combine both changes in a single PR, as the changes are small and simple enough and touch the same file.

## Changes
### `BlockRenderer`
The docs state:
> You can return a string to render this block yourself, or return nothing (null or undefined) to defer to the default renderer.

The possibility to return `null` or `undefined` was missing from the TypeScript definition, meaning it wasn't possible to defer to the default renderer in a `BlockRenderer` function.

### `defaultBlockTag`
The docs state:
> If you don't want any parent block tag, you can set `defaultBlockTag` to `null`.

The TypeScript definition didn't allow for this, as it required a `string` to be returned.

## Related issues
- **`BlockRenderer`:** #132 
- **`defaultBlockTag`:** #197 