### PR TITLE
Accept custom block tags map as an option

### DIFF
--- a/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
+++ b/packages/draft-js-export-html/src/__tests__/stateToHTML-test.js
@@ -279,4 +279,32 @@ describe('stateToHTML', () => {
       'a',
     );
   });
+
+  it('should support custom block tags map', () => {
+    let contentState = convertFromRaw(
+      {
+        entityMap: {},
+        blocks: [{
+          key: '33nh8',
+          text: 'text',
+          type: 'unstyled',
+          depth: 0,
+          inlineStyleRange: [],
+          entityRanges: [],
+        }],
+      },
+    );
+
+    expect(stateToHTML(contentState)).toBe(
+      '<p>text</p>',
+    );
+
+    expect(stateToHTML(contentState, {
+      blockTagsMap: {
+        unstyled: 'h1',
+      },
+    })).toBe(
+      '<h1>text</h1>',
+    );
+  });
 });


### PR DESCRIPTION
The previous implementation was supporting only predefined HTML tags for the standard block types which come from draft.js out of the box. These changes provide a simple and quick way bypass this and allows users to use custom HTML tags for block types.

The main use case this solves is for people who use custom block types in draft.js.

Simply create an object with key value pairs where key is the block type and value is the HTML tag you want. Afterwards just pass it as an option `blockTagsMap` to `convertFromRaw` function.