### PR TITLE
draft-js-export-html add inlineStyleFn typescript definition

### DIFF
--- a/packages/draft-js-export-html/typings/index.d.ts
+++ b/packages/draft-js-export-html/typings/index.d.ts
@@ -3,6 +3,7 @@
 declare module 'draft-js-export-html' {
     import draftjs = require("draft-js");
 
+    type InlineStyleFn = (style: draftjs.DraftInlineStyle) => RenderConfig|undefined;
     type BlockStyleFn = (block: draftjs.ContentBlock) => RenderConfig|undefined;
     type EntityStyleFn = (entity: draftjs.EntityInstance) => RenderConfig|undefined;
     type BlockRenderer = (block: draftjs.ContentBlock) => string;
@@ -18,6 +19,7 @@ declare module 'draft-js-export-html' {
         blockRenderers?: { [blockType: string]: BlockRenderer };
         blockStyleFn?: BlockStyleFn;
         entityStyleFn?: EntityStyleFn;
+        inlineStyleFn?: InlineStyleFn;
     }
 
     export function stateToHTML(content: draftjs.ContentState, options?: Options): string;


### PR DESCRIPTION
Added missing typescript [inlineStyleFn](https://www.npmjs.com/package/draft-js-export-html#inlinestylesfn) definition (same as flow definition)