### PR TITLE
fix(markdown): trimming styled text

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -224,6 +224,10 @@ class MarkupGenerator {
             const leftPad = contentLength - content.length;
             content = content.trimRight();
             const rightPad = contentLength - content.length - leftPad;
+if (!content.length) {
+  // Return the original text if there is nothing left after trimming.
+  return text;
+}
 
             // NOTE: We attempt some basic character escaping here, although
             // I don't know if escape sequences are really valid in markdown,

--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -218,13 +218,20 @@ class MarkupGenerator {
             if (blockType === BLOCK_TYPE.CODE) {
               return content;
             }
+
+            const contentLength = content.length;
+            content = content.trimStart();
+            const leftPad = contentLength - content.length;
+            content = content.trimEnd();
+            const rightPad = contentLength - content.length - leftPad;
+
             // NOTE: We attempt some basic character escaping here, although
             // I don't know if escape sequences are really valid in markdown,
             // there's not a canonical spec to lean on.
             if (style.has(CODE)) {
               return '`' + encodeCode(content) + '`';
             }
-            content = encodeContent(text);
+            content = encodeContent(text.trim());
             if (style.has(BOLD)) {
               content = `**${content}**`;
             }
@@ -239,7 +246,8 @@ class MarkupGenerator {
               // TODO: encode `~`?
               content = `~~${content}~~`;
             }
-            return content;
+            content = content.padStart(content.length + leftPad);
+            return content.padEnd(content.length + rightPad);
           })
           .join('');
         let entity = entityKey ? contentState.getEntity(entityKey) : null;

--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -220,9 +220,9 @@ class MarkupGenerator {
             }
 
             const contentLength = content.length;
-            content = content.trimStart();
+            content = content.trimLeft();
             const leftPad = contentLength - content.length;
-            content = content.trimEnd();
+            content = content.trimRight();
             const rightPad = contentLength - content.length - leftPad;
 
             // NOTE: We attempt some basic character escaping here, although

--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -235,7 +235,7 @@ if (!content.length) {
             if (style.has(CODE)) {
               return '`' + encodeCode(content) + '`';
             }
-            content = encodeContent(text.trim());
+            content = encodeContent(content);
             if (style.has(BOLD)) {
               content = `**${content}**`;
             }

--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -6,6 +6,18 @@ a
 {"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
 asd**f**
 
+>> Single Inline Style With Space After
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf .","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":2,"style":"BOLD"}],"entityRanges":[]}]}
+asd**f** .
+
+>> Single Inline Style With Space Before
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asd f.","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":2,"style":"BOLD"}],"entityRanges":[]}]}
+asd **f**.
+
+>> Single Inline Style With Space Either Side
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asd f .","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":3,"style":"BOLD"}],"entityRanges":[]}]}
+asd **f** .
+
 >> Nested Inline Style
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":10,"style":"BOLD"},{"offset":0,"length":10,"style":"ITALIC"}],"entityRanges":[]}]}
 _**BoldItalic**_


### PR DESCRIPTION
Resolves #208

If a word including its surrounding whitespace is formatted, the markdown output (while valid) will not correctly render the formatting.