### PR TITLE
Update block renderer types to match readme

### DIFF
--- a/packages/draft-js-export-html/typings/index.d.ts
+++ b/packages/draft-js-export-html/typings/index.d.ts
@@ -5,7 +5,7 @@ declare module 'draft-js-export-html' {
 
     type BlockStyleFn = (block: draftjs.ContentBlock) => RenderConfig|undefined;
     type EntityStyleFn = (entity: draftjs.EntityInstance) => RenderConfig|undefined;
-    type BlockRenderer = (block: draftjs.ContentBlock) => string;
+    type BlockRenderer = (block: draftjs.ContentBlock) => string|null|undefined;
     type RenderConfig = {
         element?: string;
         attributes?: any;


### PR DESCRIPTION
The readme states:

> You can return a string to render this block yourself, or return nothing (null or undefined) to defer to the default renderer.

This PR updates the types to reflect this.