### PR TITLE
Use * instead of _ for italics

### DIFF
--- a/packages/draft-js-export-markdown/src/stateToMarkdown.js
+++ b/packages/draft-js-export-markdown/src/stateToMarkdown.js
@@ -244,7 +244,7 @@ if (!content.length) {
               content = `++${content}++`;
             }
             if (style.has(ITALIC)) {
-              content = `_${content}_`;
+              content = `*${content}*`;
             }
             if (style.has(STRIKETHROUGH)) {
               // TODO: encode `~`?

--- a/packages/draft-js-export-markdown/test/test-cases.txt
+++ b/packages/draft-js-export-markdown/test/test-cases.txt
@@ -20,11 +20,11 @@ asd **f** .
 
 >> Nested Inline Style
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":10,"style":"BOLD"},{"offset":0,"length":10,"style":"ITALIC"}],"entityRanges":[]}]}
-_**BoldItalic**_
+***BoldItalic***
 
 >> Adjacent Inline Style
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":4,"length":6,"style":"BOLD"},{"offset":0,"length":4,"style":"ITALIC"}],"entityRanges":[]}]}
-_Bold_**Italic**
+*Bold***Italic**
 
 >> Image with alt
 {"entityMap":{"0":{"type":"IMAGE","mutability":"MUTABLE","data":{"src":"/a.jpg","alt":"x"}}},"blocks":[{"key":"f131g","text":"Hello World.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":5,"length":1,"key":0}]}]}


### PR DESCRIPTION
This fixes issues converting text with italics in the middle of the word, for example

aaaaaa<i>italic</i>bbbb

Or when the space at the end of the word is italicized:

aaaaa<i>italic </i>bbbb

Or when mixing bold / italic / bold+italic

aaaa<i>italic<b>bolditalic</b>italic</i>bbb

I have tested rendering the resulting markdown with both ReactMarkdown (https://github.com/remarkjs/react-markdown) and on iOS with the builtin AttributedString to confirm it renders correctly