### PR TITLE
InlineCreators type update

### DIFF
--- a/packages/draft-js-import-html/typings/index.d.ts
+++ b/packages/draft-js-import-html/typings/index.d.ts
@@ -3,6 +3,7 @@
 declare module 'draft-js-import-html' {
     import draftjs = require('draft-js');
 
+    type EntityMutability = 'IMMUTABLE' | 'MUTABLE' | 'SEGMENTED';
     export type CustomBlockFn = (element: Element) => undefined | null | CustomBlockObject;
     export type CustomInlineFn = (element: Element, inlineCreators: InlineCreators) => undefined | null | Style | draftjs.EntityInstance;
 
@@ -13,7 +14,7 @@ declare module 'draft-js-import-html' {
 
     export type InlineCreators = {
         Style: (style: string) => Style;
-        Entity: (type: string, data?: Object) => draftjs.EntityInstance;
+        Entity: (type: string, data?: Object, mutability?: EntityMutability) => draftjs.EntityInstance;
     };
 
     export type Style = {


### PR DESCRIPTION
Entity  type mismatch between in [draft-js-import-element](https://github.com/pawritra/draft-js-utils/blob/master/packages/draft-js-import-element/src/stateFromElement.js) and draft-js-import-html